### PR TITLE
Only show cellular sensors if the simcard is present.

### DIFF
--- a/custom_components/ha_glinet/entities/sensor.py
+++ b/custom_components/ha_glinet/entities/sensor.py
@@ -121,6 +121,7 @@ SYSTEM_SENSORS: tuple[SystemStatusEntityDescription, ...] = (
 class HubSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[GLinetHub], int | float | str | None]
     extra_attributes_fn: Callable[[GLinetHub], dict[str, Any]] | None = None
+    requires_sim: bool = False
 
 
 HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
@@ -134,6 +135,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
     ),
     HubSensorEntityDescription(
         key="cellular_signal",
+        requires_sim=True,
         name="Cellular signal",
         has_entity_name=True,
         icon="mdi:signal-cellular-2",
@@ -153,6 +155,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         icon="mdi:signal-cellular-outline",
         native_unit_of_measurement="dBm",
         state_class=SensorStateClass.MEASUREMENT,
+        requires_sim=True,
         value_fn=lambda hub: _first_int(
             hub.cellular_status,
             ("rssi",),
@@ -166,6 +169,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         icon="mdi:signal-variant",
         native_unit_of_measurement="dBm",
         state_class=SensorStateClass.MEASUREMENT,
+        requires_sim=True,
         value_fn=lambda hub: _first_int(
             hub.cellular_status,
             ("rsrp",),
@@ -179,6 +183,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         icon="mdi:signal-distance-variant",
         native_unit_of_measurement="dB",
         state_class=SensorStateClass.MEASUREMENT,
+        requires_sim=True,
         value_fn=lambda hub: _first_int(
             hub.cellular_status,
             ("rsrq",),
@@ -192,6 +197,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         icon="mdi:signal-3g",
         native_unit_of_measurement="dB",
         state_class=SensorStateClass.MEASUREMENT,
+        requires_sim=True,
         value_fn=lambda hub: _first_int(
             hub.cellular_status,
             ("sinr",),
@@ -203,6 +209,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         name="Cellular band",
         has_entity_name=True,
         icon="mdi:cellphone-wireless",
+        requires_sim=True,
         value_fn=lambda hub: _first_value(
             hub.cellular_status,
             ("band", "network_type", "service_type"),
@@ -214,6 +221,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         name="Cellular network",
         has_entity_name=True,
         icon="mdi:signal-cellular-outline",
+        requires_sim=True,
         value_fn=lambda hub: _first_value(
             hub.cellular_status,
             ("network", "operator", "operator_name", "carrier", "mode", "service_type"),
@@ -222,6 +230,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
     ),
     HubSensorEntityDescription(
         key="sms_messages",
+        requires_sim=True,
         name="Text messages",
         has_entity_name=True,
         icon="mdi:message-text",
@@ -307,6 +316,7 @@ async def async_setup_entry(
     entities.extend(
         HubStatusSensor(hub=hub, entity_description=description)
         for description in HUB_SENSORS
+        if not description.requires_sim or hub.has_sim_card
     )
     entities.append(
         SystemUptimeSensor(

--- a/custom_components/ha_glinet/entities/sensor.py
+++ b/custom_components/ha_glinet/entities/sensor.py
@@ -315,7 +315,6 @@ async def async_setup_entry(
     ]
     for description in HUB_SENSORS:
         if description.requires_sim and not hub.has_sim_card:
-            _LOGGER.debug("Skipping sensor %s (requires SIM)", description.key)
             continue
         entities.append(HubStatusSensor(hub=hub, entity_description=description))
     entities.append(

--- a/custom_components/ha_glinet/entities/sensor.py
+++ b/custom_components/ha_glinet/entities/sensor.py
@@ -313,11 +313,11 @@ async def async_setup_entry(
         for description in SYSTEM_SENSORS
         if description.value_fn(hub.router_status) is not None
     ]
-    entities.extend(
-        HubStatusSensor(hub=hub, entity_description=description)
-        for description in HUB_SENSORS
-        if not description.requires_sim or hub.has_sim_card
-    )
+    for description in HUB_SENSORS:
+        if description.requires_sim and not hub.has_sim_card:
+            _LOGGER.debug("Skipping sensor %s (requires SIM)", description.key)
+            continue
+        entities.append(HubStatusSensor(hub=hub, entity_description=description))
     entities.append(
         SystemUptimeSensor(
             hub=hub,
@@ -389,6 +389,18 @@ class HubStatusSensor(SensorEntity):
     @property
     def unique_id(self) -> str:
         return f"glinet_sensor/{self.hub.device_mac}/{self.entity_description.key}"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self.entity_description.requires_sim:
+            return self.hub.has_sim_card
+        return True
+
+    @property
+    def entity_registry_visible_default(self) -> bool:
+        if self.entity_description.requires_sim:
+            return self.hub.has_sim_card
+        return True
 
     @property
     def native_value(self) -> int | float | str | None:

--- a/custom_components/ha_glinet/hub.py
+++ b/custom_components/ha_glinet/hub.py
@@ -508,6 +508,13 @@ class GLinetHub:
         return self._default_modem_bus
 
     @property
+    def has_sim_card(self) -> bool:
+        for modem in self._modems.values():
+            if modem.get("simcard") or modem.get("sim_card") or modem.get("sim"):
+                return True
+        return False
+
+    @property
     def event_device_added(self) -> str:
         return f"{DOMAIN}-device-new-{self._factory_mac}"
 

--- a/custom_components/ha_glinet/hub.py
+++ b/custom_components/ha_glinet/hub.py
@@ -508,9 +508,16 @@ class GLinetHub:
         return self._default_modem_bus
 
     @property
+    def has_modem(self) -> bool:
+        return bool(self._modems)
+
+    @property
     def has_sim_card(self) -> bool:
+        if not self._modems:
+            return False
         for modem in self._modems.values():
-            if modem.get("simcard") or modem.get("sim_card") or modem.get("sim"):
+            sim_status = modem.get("simcard") or modem.get("sim_card") or modem.get("sim")
+            if sim_status not in (None, False, 0, "none", ""):
                 return True
         return False
 


### PR DESCRIPTION
Since I don't use a sim card, I don't need/want all the cell sensors showing up. This automatically hides the sensors when a sim card isn't present. (or in theory, I don't have one to test)