### PR TITLE
v1.4.3

### DIFF
--- a/custom_components/ha_glinet/entities/device_tracker.py
+++ b/custom_components/ha_glinet/entities/device_tracker.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,8 @@ def pytest_configure() -> None:
         device_tracker.CONF_CONSIDER_HOME = "consider_home"
         device_tracker.DEFAULT_CONSIDER_HOME = types.SimpleNamespace(total_seconds=lambda: 180)
         device_tracker.DOMAIN = "device_tracker"
+        device_tracker.SourceType = types.SimpleNamespace(ROUTER="router")
+        device_tracker.ScannerEntity = object
 
         const = types.ModuleType("homeassistant.const")
         const.CONF_HOST = "host"


### PR DESCRIPTION
Fixes:
- Replace deprecated ScannerEntity import path to resolve Home Assistant Core 2027.6 deprecation warning.