### PR TITLE
V1.4.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,8 @@ jobs:
             integration. Use Markdown bullets. Do not invent changes. Use the
             commit subject, body, and changed files to summarize what changed. 
             If the changes include fixes within the same release related to new
-            features being introduced, don't mention the fixes. Only the new releases
+            features being introduced, don't mention the fixes. Only the new releases.
+            Also do not include notes about changes to files around versioning.
           prompt: |
             Create release notes for ha-glinet.
 

--- a/custom_components/ha_glinet/entities/sensor.py
+++ b/custom_components/ha_glinet/entities/sensor.py
@@ -354,12 +354,17 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
     ),
     HubSensorEntityDescription(
         key="sms_messages",
-        name="Text messages",
+        name="Unread messages",
         has_entity_name=True,
-        icon="mdi:message-text",
+        icon="mdi:email-alert",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda hub: len(hub.sms_messages),
+        value_fn=lambda hub: sum(
+            1 for m in hub.sms_messages.values() if m.status == 0
+        ),
         extra_attributes_fn=lambda hub: {
+            "unread_count": sum(
+                1 for m in hub.sms_messages.values() if m.status == 0
+            ),
             "message_count": len(hub.sms_messages),
             "incoming_count": sum(
                 1 for m in hub.sms_messages.values() if m.direction == "incoming"

--- a/custom_components/ha_glinet/entities/sensor.py
+++ b/custom_components/ha_glinet/entities/sensor.py
@@ -165,7 +165,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         icon="mdi:download-network",
         device_class=SensorDeviceClass.DATA_SIZE,
         native_unit_of_measurement="B",
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
         value_fn=lambda hub: hub.total_traffic_download,
     ),
     HubSensorEntityDescription(
@@ -175,7 +175,7 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         icon="mdi:upload-network",
         device_class=SensorDeviceClass.DATA_SIZE,
         native_unit_of_measurement="B",
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
         value_fn=lambda hub: hub.total_traffic_upload,
     ),
     HubSensorEntityDescription(

--- a/custom_components/ha_glinet/entities/sensor.py
+++ b/custom_components/ha_glinet/entities/sensor.py
@@ -179,14 +179,25 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         value_fn=lambda hub: hub.total_traffic_upload,
     ),
     HubSensorEntityDescription(
-        key="wan_ip",
-        name="WAN IP",
+        key="cellular_ipv4",
+        name="Cellular WAN IPv4",
         has_entity_name=True,
         icon="mdi:ip-network",
         value_fn=lambda hub: get_first_value(
             hub.cellular_status,
             ("ip",),
             nested=("modem", "cellular", "sim", "network", "ipv4"),
+        ),
+    ),
+    HubSensorEntityDescription(
+        key="cellular_ipv6",
+        name="Cellular WAN IPv6",
+        has_entity_name=True,
+        icon="mdi:ip-network",
+        value_fn=lambda hub: get_first_value(
+            hub.cellular_status,
+            ("ip",),
+            nested=("modem", "cellular", "sim", "network", "ipv6"),
         ),
     ),
     HubSensorEntityDescription(
@@ -534,6 +545,16 @@ FEATURE_SENSOR_MAP: dict[str, str] = {
 
 
 def _sensor_is_enabled(hub: GLinetHub, description: HubSensorEntityDescription) -> bool:
+    if description.key in {"cellular_ipv4", "cellular_ipv6"}:
+        monitors = hub.wan_status_monitors
+        protocol = "ipv4" if description.key == "cellular_ipv4" else "ipv6"
+        if monitors is None:
+            return any(
+                iface.get("interface") == "modem_0001"
+                for iface in _wan_interfaces(hub)
+            )
+        return f"modem_0001:{protocol}" in monitors
+
     feature = FEATURE_SENSOR_MAP.get(description.key)
     return feature is None or hub.feature_enabled(feature)
 
@@ -849,7 +870,7 @@ class HubStatusSensor(CoordinatorEntity[GLinetHub], SensorEntity):
     def available(self) -> bool:
         if not super().available:
             return False
-        if self.entity_description.key == "wan_ip":
+        if self.entity_description.key in {"cellular_ipv4", "cellular_ipv6"}:
             return self.native_value is not None
         if self.entity_description.key in {
             "repeater_ssid",

--- a/custom_components/ha_glinet/entities/sensor.py
+++ b/custom_components/ha_glinet/entities/sensor.py
@@ -41,6 +41,28 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 
+def _get_cellular_ip(hub: GLinetHub, version: str) -> str | None:
+    status = hub.cellular_status
+    if not isinstance(status, dict):
+        return None
+    modems = status.get("modems")
+    if not isinstance(modems, list):
+        return None
+    for modem in modems:
+        if not isinstance(modem, dict):
+            continue
+        network = modem.get("network")
+        if not isinstance(network, dict):
+            continue
+        ip_info = network.get(version)
+        if not isinstance(ip_info, dict):
+            continue
+        ip = ip_info.get("ip")
+        if ip not in (None, ""):
+            return str(ip)
+    return None
+
+
 @dataclass(frozen=True, kw_only=True)
 class SystemStatusEntityDescription(SensorEntityDescription):
     value_fn: Callable[[RouterStatus | None], int | float | None]
@@ -183,22 +205,14 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         name="Cellular WAN IPv4",
         has_entity_name=True,
         icon="mdi:ip-network",
-        value_fn=lambda hub: get_first_value(
-            hub.cellular_status,
-            ("ip",),
-            nested=("modem", "cellular", "sim", "network", "ipv4"),
-        ),
+        value_fn=lambda hub: _get_cellular_ip(hub, "ipv4"),
     ),
     HubSensorEntityDescription(
         key="cellular_ipv6",
         name="Cellular WAN IPv6",
         has_entity_name=True,
         icon="mdi:ip-network",
-        value_fn=lambda hub: get_first_value(
-            hub.cellular_status,
-            ("ip",),
-            nested=("modem", "cellular", "sim", "network", "ipv6"),
-        ),
+        value_fn=lambda hub: _get_cellular_ip(hub, "ipv6"),
     ),
     HubSensorEntityDescription(
         key="firewall_rules",

--- a/custom_components/ha_glinet/hub.py
+++ b/custom_components/ha_glinet/hub.py
@@ -213,7 +213,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
         feature_map = {
             FEATURE_CELLULAR: ["cellular_"],
-            FEATURE_SMS: ["sms_messages", "text_messages"],
+            FEATURE_SMS: ["sms_messages", "unread_messages"],
             FEATURE_REPEATER: [
                 "repeater_",
                 "wifi_network",

--- a/custom_components/ha_glinet/hub.py
+++ b/custom_components/ha_glinet/hub.py
@@ -183,8 +183,20 @@ class GLinetHub(DataUpdateCoordinator[None]):
         return feature in self.enabled_features
 
     def _wan_status_entity_selected(self, unique_id: str) -> bool:
-        prefix = f"glinet_sensor/{self.device_mac}/wan_status_"
-        if not unique_id.startswith(prefix):
+        prefix = f"glinet_sensor/{self.device_mac}/"
+
+        cellular_ip_map = {
+            f"{prefix}cellular_ipv4": "modem_0001:ipv4",
+            f"{prefix}cellular_ipv6": "modem_0001:ipv6",
+        }
+        if unique_id in cellular_ip_map:
+            monitors = self.wan_status_monitors
+            if monitors is None:
+                return True
+            return cellular_ip_map[unique_id] in monitors
+
+        wan_prefix = f"{prefix}wan_status_"
+        if not unique_id.startswith(wan_prefix):
             return True
 
         monitors = self.wan_status_monitors
@@ -197,7 +209,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
             if separator and protocol in {"ipv4", "ipv6"} and interface:
                 selected_parts.append((interface, protocol))
 
-        suffix = unique_id.removeprefix(prefix)
+        suffix = unique_id.removeprefix(wan_prefix)
         return any(
             suffix == interface or suffix == f"{interface}_{protocol}"
             for interface, protocol in selected_parts

--- a/custom_components/ha_glinet/manifest.json
+++ b/custom_components/ha_glinet/manifest.json
@@ -23,5 +23,5 @@
   "requirements": [
     "passlib==1.7.4"
   ],
-  "version": "1.4.7"
+  "version": "1.4.8"
 }

--- a/custom_components/ha_glinet/strings.json
+++ b/custom_components/ha_glinet/strings.json
@@ -124,7 +124,7 @@
         "name": "Cellular APN"
       },
       "sms_messages": {
-        "name": "Text messages"
+        "name": "Unread messages"
       },
       "repeater_state": {
         "name": "Repeater state",

--- a/custom_components/ha_glinet/strings.json
+++ b/custom_components/ha_glinet/strings.json
@@ -168,8 +168,11 @@
       "fan_temperature": {
         "name": "Fan threshold temperature"
       },
-      "wan_ip": {
-        "name": "WAN IP"
+      "cellular_ipv4": {
+        "name": "Cellular WAN IPv4"
+      },
+      "cellular_ipv6": {
+        "name": "Cellular WAN IPv6"
       },
       "wg_server_users": {
         "name": "WireGuard server users"

--- a/custom_components/ha_glinet/translations/en.json
+++ b/custom_components/ha_glinet/translations/en.json
@@ -150,6 +150,12 @@
       "repeater_bssid": {
         "name": "Repeater BSSID"
       },
+      "cellular_ipv4": {
+        "name": "Cellular WAN IPv4"
+      },
+      "cellular_ipv6": {
+        "name": "Cellular WAN IPv6"
+      },
       "wg_server_users": {
         "name": "WireGuard server users"
       },

--- a/custom_components/ha_glinet/translations/en.json
+++ b/custom_components/ha_glinet/translations/en.json
@@ -112,7 +112,7 @@
         "name": "Cellular network"
       },
       "sms_messages": {
-        "name": "Text messages"
+        "name": "Unread messages"
       },
       "repeater_state": {
         "name": "Repeater state",

--- a/docs/cellular.md
+++ b/docs/cellular.md
@@ -16,7 +16,8 @@ To enable this feature, check the **Cellular** option under **Enabled Features**
 
 | Entity | Description | API Source |
 | --- | --- | --- |
-| **WAN IP** | The IP address assigned to the cellular internet interface. Hidden when cellular internet is unavailable. | `modem/get_status` |
+| **Cellular WAN IPv4** | The IP address assigned to the cellular internet interface. Hidden when cellular internet is unavailable. | `modem/get_status` |
+| **Cellular WAN IPv6** | The IPv6 address assigned to the cellular internet interface. Hidden when cellular internet is unavailable. | `modem/get_status` |
 | **Cellular signal** | Overall cellular signal strength percentage. | `modem/get_status` |
 | **Cellular RSSI** | Received Signal Strength Indicator in dBm. | `modem/get_status` |
 | **Cellular RSRP** | Reference Signal Received Power in dBm. | `modem/get_status` |

--- a/docs/sms.md
+++ b/docs/sms.md
@@ -16,7 +16,7 @@ To enable this feature, check the **SMS** option under **Enabled Features** in t
 
 | Entity | Description | API Source |
 | --- | --- | --- |
-| **Text messages** | Count of SMS messages currently stored on the SIM card/modem. Attributes include `message_count`, `incoming_count`, `outgoing_count`, and a full `messages` list with per-message details. | `modem/get_sms_list` |
+| **Unread messages** | Count of unread SMS messages (status `0`) currently stored on the SIM card/modem. Attributes include `unread_count`, `message_count`, `incoming_count`, `outgoing_count`, and a full `messages` list with per-message details. | `modem/get_sms_list` |
 
 The `messages` attribute contains objects with the following fields:
 
@@ -57,7 +57,7 @@ Deletes SMS messages from the router based on a scope or specific ID.
   - `11` — All SMS.
   - `0` — All unread SMS.
   - `1` — All read SMS.
-- **`message_id`** (Optional): The unique ID of the message to delete. Found in the `Text messages` sensor attributes. Required if `scope` is `10`.
+- **`message_id`** (Optional): The unique ID of the message to delete. Found in the `Unread messages` sensor attributes. Required if `scope` is `10`.
 - **`mac`** (Optional): Target a specific router by MAC address.
 
 ### `refresh_sms`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ha-glinet"
-version = "1.4.7"
+version = "1.4.8"
 description = "Unified GL-INet Home Assistant integration with bundled API client"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,7 @@ def pytest_configure() -> None:
         sensor.SensorStateClass = types.SimpleNamespace(
             MEASUREMENT="measurement",
             TOTAL_INCREASING="total_increasing",
+            TOTAL="total",
         )
         switch = types.ModuleType("homeassistant.components.switch")
         switch.SwitchEntity = object

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -925,6 +925,63 @@ async def test_async_initialize_hub_cleans_up_unselected_wan_status_sensors(
     mock_er.async_remove.assert_any_call("sensor.repeater_ipv6_status")
 
 
+async def test_async_initialize_hub_cleans_up_unselected_cellular_ip_sensors(
+    monkeypatch,
+) -> None:
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._settings = {
+        CONF_ADD_ALL_DEVICES: True,
+        CONF_WAN_STATUS_MONITORS: ["wan:ipv4", "modem_0001:ipv4"],
+        CONF_ENABLED_FEATURES: ["cellular"],
+    }
+    hub._entry = types.SimpleNamespace(entry_id="test_entry")
+    hub.hass = MagicMock()
+    hub._late_init_complete = True
+    hub._factory_mac = "00:11:22:33:44:55"
+
+    selected_ipv4 = types.SimpleNamespace(
+        entity_id="sensor.cellular_wan_ipv4",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_ipv4",
+        domain="sensor",
+    )
+    unselected_ipv6 = types.SimpleNamespace(
+        entity_id="sensor.cellular_wan_ipv6",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_ipv6",
+        domain="sensor",
+    )
+    unrelated = types.SimpleNamespace(
+        entity_id="sensor.connected_clients",
+        unique_id="glinet_sensor/00:11:22:33:44:55/connected_clients",
+        domain="sensor",
+    )
+
+    mock_er = MagicMock()
+    mock_er.async_remove = MagicMock()
+
+    import homeassistant.helpers.entity_registry as er
+
+    monkeypatch.setattr(er, "async_get", lambda _: mock_er)
+    monkeypatch.setattr(
+        er,
+        "async_entries_for_config_entry",
+        MagicMock(
+            return_value=[
+                selected_ipv4,
+                unselected_ipv6,
+                unrelated,
+            ]
+        ),
+    )
+
+    hub.refresh_session_token = _noop
+    hub.fetch_all_data = _noop
+
+    await hub.async_initialize_hub()
+
+    assert mock_er.async_remove.call_count == 1
+    mock_er.async_remove.assert_any_call("sensor.cellular_wan_ipv6")
+
+
 async def test_fetch_connected_devices_respects_add_all_devices_option(monkeypatch) -> None:
     import custom_components.ha_glinet.hub as hub_module
     monkeypatch.setattr(hub_module, "async_dispatcher_send", _noop_arg)

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -156,3 +156,53 @@ def test_sms_sensor_returns_zero_when_no_unread() -> None:
 
     assert desc.value_fn(hub) == 0
     assert desc.extra_attributes_fn(hub)["unread_count"] == 0
+
+
+def test_cellular_ip_sensors_are_enabled() -> None:
+    from custom_components.ha_glinet.entities.sensor import HUB_SENSORS, _sensor_is_enabled
+
+    desc_v4 = next(d for d in HUB_SENSORS if d.key == "cellular_ipv4")
+    desc_v6 = next(d for d in HUB_SENSORS if d.key == "cellular_ipv6")
+
+    # Case 1: wan_status_monitors is None (default), modem_0001 is in _wan_interfaces
+    hub = types.SimpleNamespace(
+        wan_status_monitors=None,
+        kmwan_status={
+            "interfaces": [
+                {"interface": "wan"},
+                {"interface": "modem_0001"},
+            ]
+        }
+    )
+    assert _sensor_is_enabled(hub, desc_v4) is True
+    assert _sensor_is_enabled(hub, desc_v6) is True
+
+    # Case 2: wan_status_monitors is None (default), modem_0001 is NOT in _wan_interfaces
+    hub = types.SimpleNamespace(
+        wan_status_monitors=None,
+        kmwan_status={
+            "interfaces": [
+                {"interface": "wan"},
+                {"interface": "wwan"},
+            ]
+        }
+    )
+    assert _sensor_is_enabled(hub, desc_v4) is False
+    assert _sensor_is_enabled(hub, desc_v6) is False
+
+    # Case 3: wan_status_monitors is configured, and modem_0001:ipv4 is selected
+    hub = types.SimpleNamespace(
+        wan_status_monitors={"modem_0001:ipv4", "wan:ipv4"},
+        kmwan_status={}
+    )
+    assert _sensor_is_enabled(hub, desc_v4) is True
+    assert _sensor_is_enabled(hub, desc_v6) is False
+
+    # Case 4: wan_status_monitors is configured, and modem_0001:ipv6 is selected
+    hub = types.SimpleNamespace(
+        wan_status_monitors={"modem_0001:ipv6", "wwan:ipv4"},
+        kmwan_status={}
+    )
+    assert _sensor_is_enabled(hub, desc_v4) is False
+    assert _sensor_is_enabled(hub, desc_v6) is True
+

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -34,6 +34,7 @@ def _install_sensor_dependency_stubs() -> None:
     sensor.SensorStateClass = types.SimpleNamespace(
         MEASUREMENT="measurement",
         TOTAL_INCREASING="total_increasing",
+        TOTAL="total",
     )
     sys.modules.setdefault("homeassistant.components.sensor", sensor)
 

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -206,3 +206,52 @@ def test_cellular_ip_sensors_are_enabled() -> None:
     assert _sensor_is_enabled(hub, desc_v4) is False
     assert _sensor_is_enabled(hub, desc_v6) is True
 
+
+def test_get_cellular_ip_resolves_correctly() -> None:
+    from custom_components.ha_glinet.entities.sensor import _get_cellular_ip
+
+    # Case 1: IPv4 is available, IPv6 is not available
+    hub = types.SimpleNamespace(
+        cellular_status={
+            "modems": [
+                {
+                    "bus": "0001:01:00.0",
+                    "network": {
+                        "status": 0,
+                        "ipv4": {
+                            "gateway": "10.164.158.132",
+                            "ip": "10.164.158.131",
+                        },
+                    },
+                }
+            ]
+        }
+    )
+
+    assert _get_cellular_ip(hub, "ipv4") == "10.164.158.131"
+    assert _get_cellular_ip(hub, "ipv6") is None
+
+    # Case 2: Both IPv4 and IPv6 are available
+    hub = types.SimpleNamespace(
+        cellular_status={
+            "modems": [
+                {
+                    "bus": "0001:01:00.0",
+                    "network": {
+                        "status": 0,
+                        "ipv4": {
+                            "ip": "10.164.158.131",
+                        },
+                        "ipv6": {
+                            "ip": "2001:db8::1",
+                        },
+                    },
+                }
+            ]
+        }
+    )
+
+    assert _get_cellular_ip(hub, "ipv4") == "10.164.158.131"
+    assert _get_cellular_ip(hub, "ipv6") == "2001:db8::1"
+
+

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -117,3 +117,42 @@ def test_wan_status_helpers_report_interface_protocol_state() -> None:
 
     unknown_sensor = WanStatusSensor(hub, "custom_wan", {"ipv4"})
     assert unknown_sensor._attr_name == "custom_wan status"
+
+
+def test_sms_sensor_counts_only_unread_messages() -> None:
+    from custom_components.ha_glinet.entities.sensor import HUB_SENSORS
+    from custom_components.ha_glinet.models import SmsMessage
+
+    desc = next(d for d in HUB_SENSORS if d.key == "sms_messages")
+
+    unread = SmsMessage(message_id="1", phone_number="+44123", text="a", status=0)
+    read = SmsMessage(message_id="2", phone_number="+44456", text="b", status=1)
+    sent = SmsMessage(message_id="3", phone_number="+44789", text="c", status=2)
+
+    hub = types.SimpleNamespace(
+        sms_messages={"1": unread, "2": read, "3": sent},
+    )
+
+    assert desc.value_fn(hub) == 1
+    attrs = desc.extra_attributes_fn(hub)
+    assert attrs["unread_count"] == 1
+    assert attrs["message_count"] == 3
+    assert attrs["incoming_count"] == 2
+    assert attrs["outgoing_count"] == 1
+
+
+def test_sms_sensor_returns_zero_when_no_unread() -> None:
+    from custom_components.ha_glinet.entities.sensor import HUB_SENSORS
+    from custom_components.ha_glinet.models import SmsMessage
+
+    desc = next(d for d in HUB_SENSORS if d.key == "sms_messages")
+
+    read = SmsMessage(message_id="1", phone_number="+44123", text="a", status=1)
+    sent = SmsMessage(message_id="2", phone_number="+44456", text="b", status=2)
+
+    hub = types.SimpleNamespace(
+        sms_messages={"1": read, "2": sent},
+    )
+
+    assert desc.value_fn(hub) == 0
+    assert desc.extra_attributes_fn(hub)["unread_count"] == 0


### PR DESCRIPTION
fixes: 
- Router WAN traffic sensors outputting error message
- Text Message sensor including a count of all messages (sent, recieved, sending, etc)

features: 
- implemented initial steps for adding per interface WAN IP. 

Breaking: 
- the rework around namespaces will mean the existing WAN IP sensor will become unavailable. This will need to be manually deleted.