### PR TITLE
V1.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install test tools
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install -e ".[test]" ruff
 
       - name: Validate JSON metadata
         run: |

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Unified GL.iNet support for Home Assistant.
 
-[![GitHub Release](https://img.shields.io/github/v/release/vithurshanselvarajah/glinet-router?style=flat-square)](https://github.com/vithurshanselvarajah/glinet-router/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/vithurshanselvarajah/ha-glinet-router?style=flat-square)](https://github.com/vithurshanselvarajah/ha-glinet-router/releases)
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-orange.svg?style=flat-square)](https://github.com/hacs/integration)
-[![License](https://img.shields.io/github/license/vithurshanselvarajah/glinet-router?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/github/license/vithurshanselvarajah/ha-glinet-router?style=flat-square)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-7289DA?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/Metvr5hC3m)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
@@ -13,7 +13,7 @@ This integration brings GL.iNet routers into Home Assistant in a practical way. 
 ---
 
 ## Quick Links
-- [User Documentation & Feature Details](https://github.com/vithurshanselvarajah/glinet-router/wiki)
+- [User Documentation & Feature Details](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki)
 - [Installation Guide](#installation)
 - [Setup & Configuration](#setup)
 - [Join our Discord](https://discord.gg/Metvr5hC3m)
@@ -27,32 +27,32 @@ This integration gives you a lot of useful router data and controls out of the b
 
 | Capability | Details | Docs |
 | --- | --- | --- |
-| Config flow & discovery | Easy setup with DHCP discovery support and router URL/password configuration | [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) |
-| Router metadata | Model, firmware version, and MAC address information | [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) |
-| System monitoring | CPU temperature, load averages, memory usage, flash usage, and uptime sensors | [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) |
-| WAN monitoring | Per-interface WAN status sensors for Ethernet, Repeater, Cellular, and Tethering, reported as Up, Down, or Unknown | [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) |
-| Wi-Fi controls | Switches to enable or disable each configured Wi-Fi interface | [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) |
-| Hardware controls | System LED toggle and immediate reboot button | [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) |
-| Device tracking | Tracks connected clients with MAC address, name/alias, IP, interface type, and last-seen timestamp, including stale-device cleanup | [Entity Reference](https://github.com/vithurshanselvarajah/glinet-router/wiki/entities) |
-| Client diagnostics | Per-client upload rate, download rate, and IP address sensors | [Entity Reference](https://github.com/vithurshanselvarajah/glinet-router/wiki/entities) |
-| Unknown device management | Discover unknown devices, auto-cleanup rules, allow/blocklist controls, and manual MAC address entries | [Unknown Device Management](https://github.com/vithurshanselvarajah/glinet-router/wiki/unknown-devices) |
-| Firmware & diagnostics | Native Home Assistant firmware update entity, release notes support, and sanitized diagnostics export | [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) |
+| Config flow & discovery | Easy setup with DHCP discovery support and router URL/password configuration | [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) |
+| Router metadata | Model, firmware version, and MAC address information | [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) |
+| System monitoring | CPU temperature, load averages, memory usage, flash usage, and uptime sensors | [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) |
+| WAN monitoring | Per-interface WAN status sensors for Ethernet, Repeater, Cellular, and Tethering, reported as Up, Down, or Unknown | [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) |
+| Wi-Fi controls | Switches to enable or disable each configured Wi-Fi interface | [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) |
+| Hardware controls | System LED toggle and immediate reboot button | [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) |
+| Device tracking | Tracks connected clients with MAC address, name/alias, IP, interface type, and last-seen timestamp, including stale-device cleanup | [Entity Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/entities) |
+| Client diagnostics | Per-client upload rate, download rate, and IP address sensors | [Entity Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/entities) |
+| Unknown device management | Discover unknown devices, auto-cleanup rules, allow/blocklist controls, and manual MAC address entries | [Unknown Device Management](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/unknown-devices) |
+| Firmware & diagnostics | Native Home Assistant firmware update entity, release notes support, and sanitized diagnostics export | [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) |
 
 ### Optional modules
 
 | Module | What it adds | Docs |
 | --- | --- | --- |
-| Cellular | Cellular signal and network sensors, plus modem diagnostics | [Cellular](https://github.com/vithurshanselvarajah/glinet-router/wiki/cellular) |
-| Repeater | Scan nearby Wi-Fi networks, connect or disconnect, and manage saved networks | [Repeater](https://github.com/vithurshanselvarajah/glinet-router/wiki/repeater) |
-| SMS | Send, receive, and delete text messages from the router's SIM card | [SMS](https://github.com/vithurshanselvarajah/glinet-router/wiki/sms) |
-| VPNs | WireGuard client/server, OpenVPN client/server, Tailscale, and ZeroTier toggles | [WireGuard Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-client), [WireGuard Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-server), [OpenVPN Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-client), [OpenVPN Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-server), [Tailscale](https://github.com/vithurshanselvarajah/glinet-router/wiki/tailscale), [ZeroTier](https://github.com/vithurshanselvarajah/glinet-router/wiki/zerotier) |
-| AdGuard Home | Enable or disable AdGuard Home and DNS redirection | [AdGuard Home](https://github.com/vithurshanselvarajah/glinet-router/wiki/adguard-home) |
-| Firewall & WAN policy | DMZ, port forwarding, custom firewall rules, WAN access controls, and KMWAN/MWAN3 actions | [Firewall](https://github.com/vithurshanselvarajah/glinet-router/wiki/firewall), [Router API](https://github.com/vithurshanselvarajah/glinet-router/wiki/router-api) |
-| Smart fan controls | Monitor fan status and speed, and set temperature thresholds | [Smart Fan Controls](https://github.com/vithurshanselvarajah/glinet-router/wiki/smart-fan) |
-| MCU Battery | Monitor battery status and configure high/low temperature warnings | [MCU Battery](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-battery) |
-| MCU OLED | Configure what is displayed on the router's OLED screen | [MCU OLED](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-oled) |
-| Parental & access control | Internet access blocks and filtering rules per client | [Parental & Access Control](https://github.com/vithurshanselvarajah/glinet-router/wiki/parental-control) |
-| API playground | Send custom JSON-RPC or ubus commands and inspect the response | [API Playground](https://github.com/vithurshanselvarajah/glinet-router/wiki/playground) |
+| Cellular | Cellular signal and network sensors, plus modem diagnostics | [Cellular](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/cellular) |
+| Repeater | Scan nearby Wi-Fi networks, connect or disconnect, and manage saved networks | [Repeater](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/repeater) |
+| SMS | Send, receive, and delete text messages from the router's SIM card | [SMS](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/sms) |
+| VPNs | WireGuard client/server, OpenVPN client/server, Tailscale, and ZeroTier toggles | [WireGuard Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-client), [WireGuard Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-server), [OpenVPN Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-client), [OpenVPN Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-server), [Tailscale](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/tailscale), [ZeroTier](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/zerotier) |
+| AdGuard Home | Enable or disable AdGuard Home and DNS redirection | [AdGuard Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/adguard-home) |
+| Firewall & WAN policy | DMZ, port forwarding, custom firewall rules, WAN access controls, and KMWAN/MWAN3 actions | [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall), [Router API](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) |
+| Smart fan controls | Monitor fan status and speed, and set temperature thresholds | [Smart Fan Controls](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) |
+| MCU Battery | Monitor battery status and configure high/low temperature warnings | [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) |
+| MCU OLED | Configure what is displayed on the router's OLED screen | [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) |
+| Parental & access control | Internet access blocks and filtering rules per client | [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) |
+| API playground | Send custom JSON-RPC or ubus commands and inspect the response | [API Playground](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground) |
 
 You can turn optional features on or off during setup, or later from the Configure menu. Unsupported features on your router model will simply be skipped.
 
@@ -88,26 +88,26 @@ You can turn optional features on or off during setup, or later from the Configu
 
 ## Wiki & Documentation
 
-The main documentation lives in the project [Wiki](https://github.com/vithurshanselvarajah/glinet-router/wiki).
+The main documentation lives in the project [Wiki](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki).
 
 ### For End Users
-* [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) — What features are supported on each model.
-* [Entity Reference](https://github.com/vithurshanselvarajah/glinet-router/wiki/entities) — A list of all sensors, switches, and trackers created by the integration.
-* [Services & Actions](https://github.com/vithurshanselvarajah/glinet-router/wiki/services) — How to call services to control the router (e.g. sending SMS or connecting to repeater WiFi).
-* [Automation Templates](https://github.com/vithurshanselvarajah/glinet-router/wiki/automations) — Ready-made automations you can import (SMS notifications, etc.).
-- [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) — A quick overview of what the integration supports.
-- [Entity Reference](https://github.com/vithurshanselvarajah/glinet-router/wiki/entities) — A list of the sensors, switches, buttons, and trackers created by the integration.
-- [Services & Actions](https://github.com/vithurshanselvarajah/glinet-router/wiki/services) — How to call the router services from Home Assistant.
-- [Smart Fan Controls](https://github.com/vithurshanselvarajah/glinet-router/wiki/smart-fan) — Fan status, speed, and temperature threshold controls.
-- [Unknown Device Management](https://github.com/vithurshanselvarajah/glinet-router/wiki/unknown-devices) — Discovery, cleanup, and allow/blocklist handling for unknown devices.
+* [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) — What features are supported on each model.
+* [Entity Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/entities) — A list of all sensors, switches, and trackers created by the integration.
+* [Services & Actions](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/services) — How to call services to control the router (e.g. sending SMS or connecting to repeater WiFi).
+* [Automation Templates](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/automations) — Ready-made automations you can import (SMS notifications, etc.).
+- [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) — A quick overview of what the integration supports.
+- [Entity Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/entities) — A list of the sensors, switches, buttons, and trackers created by the integration.
+- [Services & Actions](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/services) — How to call the router services from Home Assistant.
+- [Smart Fan Controls](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) — Fan status, speed, and temperature threshold controls.
+- [Unknown Device Management](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/unknown-devices) — Discovery, cleanup, and allow/blocklist handling for unknown devices.
 
 ### For Developers
-- [Developer Reference](https://github.com/vithurshanselvarajah/glinet-router/wiki/developer-reference) — Development setup, tooling, and contribution notes.
-- [Architecture](https://github.com/vithurshanselvarajah/glinet-router/wiki/architecture) — How the integration is structured.
-- [Runtime Hub](https://github.com/vithurshanselvarajah/glinet-router/wiki/hub) — Details on the polling and coordinator logic.
-- [Router API Details](https://github.com/vithurshanselvarajah/glinet-router/wiki/router-api) — Notes on the GL.iNet JSON-RPC API.
-- [Modem API](https://github.com/vithurshanselvarajah/glinet-router/wiki/modem-api) — Cellular modem API notes.
-- [CI & Releases](https://github.com/vithurshanselvarajah/glinet-router/wiki/ci-release) — Testing and release workflows.
+- [Developer Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/developer-reference) — Development setup, tooling, and contribution notes.
+- [Architecture](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/architecture) — How the integration is structured.
+- [Runtime Hub](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub) — Details on the polling and coordinator logic.
+- [Router API Details](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) — Notes on the GL.iNet JSON-RPC API.
+- [Modem API](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/modem-api) — Cellular modem API notes.
+- [CI & Releases](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/ci-release) — Testing and release workflows.
 
 <details>
 <summary><b>Developer Quick Start</b> (Click to expand)</summary>
@@ -148,5 +148,5 @@ For support, questions, or general discussion, join the Discord:
 I use this integration at home and wanted something that fit the way I actually use GL.iNet hardware. Over time it grew into a broader setup for router control, monitoring, and automation.
 
 ### Special Thanks
-- **HarvsG** for the original [glinet-router4-integration](https://github.com/HarvsG/glinet-router4-integration) project which inspired this version.
+- **HarvsG** for the original [glinet-router4-integration](https://github.com/HarvsG/ha-glinet-router4-integration) project which inspired this version.
 - **GL.iNet** for their hardware and detailed API documentation.

--- a/custom_components/glinet_router/api/client.py
+++ b/custom_components/glinet_router/api/client.py
@@ -98,7 +98,6 @@ class GLinetApiClient:
         self.sid = sid
         self._logged_in = sid is not None
 
-
         self.system = SystemModule(self)
         self.modem = ModemModule(self)
         self.mcu = McuModule(self)
@@ -192,13 +191,9 @@ class GLinetApiClient:
             if algorithm == 1:
                 cipher_password = md5_crypt.using(salt=salt).hash(login_password)
             elif algorithm == 5:
-                cipher_password = sha256_crypt.using(salt=salt, rounds=5000).hash(
-                    login_password
-                )
+                cipher_password = sha256_crypt.using(salt=salt, rounds=5000).hash(login_password)
             elif algorithm == 6:
-                cipher_password = sha512_crypt.using(salt=salt, rounds=5000).hash(
-                    login_password
-                )
+                cipher_password = sha512_crypt.using(salt=salt, rounds=5000).hash(login_password)
             else:
                 raise ValueError("Unsupported router cipher algorithm")
 
@@ -252,6 +247,3 @@ class GLinetApiClient:
             else:
                 payload = self._build_sid_payload(method, [params], self.sid)
         return await self._send_request(payload)
-
-
-

--- a/custom_components/glinet_router/api/client.py
+++ b/custom_components/glinet_router/api/client.py
@@ -141,6 +141,15 @@ class GLinetApiClient:
             "id": 0,
         }
 
+    async def _ensure_firmware_version(self) -> None:
+        if self._firmware_version is None:
+            await self.system.get_info()
+
+    async def _is_firmware_at_least(self, version: tuple[int, int, int, int]) -> bool:
+        await self._ensure_firmware_version()
+        fw_ver = self._firmware_version
+        return fw_ver is not None and fw_ver >= version
+
     async def _send_request(
         self, payload: dict[str, Any], timeout_seconds: int = DEFAULT_TIMEOUT
     ) -> dict[str, Any] | list[Any]:

--- a/custom_components/glinet_router/api/const.py
+++ b/custom_components/glinet_router/api/const.py
@@ -3,4 +3,5 @@ from __future__ import annotations
 DEFAULT_TIMEOUT = 2
 LONG_TIMEOUT = 5
 SCAN_TIMEOUT = 30
-NEW_VPN_CLIENT_VERSION = (4, 8, 0, 0)
+FIRMWARE_4_8 = (4, 8, 0, 0)
+FIRMWARE_4_9 = (4, 9, 0, 0)

--- a/custom_components/glinet_router/api/models.py
+++ b/custom_components/glinet_router/api/models.py
@@ -4,12 +4,12 @@ from typing import Any
 
 
 class TailscaleConnection(Enum):
-
     DISCONNECTED = 0
     LOGIN_REQUIRED = 1
     AUTHORIZATION_REQUIRED = 2
     CONNECTED = 3
     CONNECTING = 4
+
 
 @dataclass
 class SystemInfo:
@@ -18,6 +18,7 @@ class SystemInfo:
     mac: str = ""
     sn: str = ""
     device_id: str = ""
+
 
 @dataclass
 class RouterStatus:
@@ -33,6 +34,7 @@ class RouterStatus:
     network: list[dict[str, Any]] = field(default_factory=list)
     mcu: dict[str, Any] = field(default_factory=dict)
 
+
 @dataclass
 class WifiInterfaceInfo:
     enabled: bool = False
@@ -40,6 +42,7 @@ class WifiInterfaceInfo:
     guest: bool = False
     hidden: bool = False
     encryption: str = ""
+
 
 @dataclass
 class ModemInfo:

--- a/custom_components/glinet_router/api/modules/base.py
+++ b/custom_components/glinet_router/api/modules/base.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 
 class BaseModule:
-
     def __init__(self, client: GLinetApiClient) -> None:
         self._client = client
 

--- a/custom_components/glinet_router/api/modules/modem.py
+++ b/custom_components/glinet_router/api/modules/modem.py
@@ -21,6 +21,10 @@ class ModemModule(BaseModule):
         response = await self._call("modem", "get_info")
         return dict(response)
 
+    async def get_sim_config(self, bus: str) -> dict[str, Any]:
+        response = await self._call("modem", "get_sim_config", {"bus": bus})
+        return dict(response)
+
     async def get_modem_info(self) -> list[ModemInfo]:
         info_response = await self.get_info()
         status_response = await self.get_status()
@@ -77,7 +81,7 @@ class ModemModule(BaseModule):
             "timeout": timeout,
         }
         if slot is not None:
-            params["slot"] = slot
+            params["slot"] = int(slot) if isinstance(slot, str) else slot
         payload = self._client._build_sid_payload(
             "call",
             ["modem", "send_sms", params],
@@ -94,13 +98,10 @@ class ModemModule(BaseModule):
         bus: str,
         scope: int,
         message_id: str | None = None,
-        slot: int | str | None = None,
     ) -> dict[str, Any]:
-        params = {"bus": bus, "scope": scope}
+        params: dict[str, Any] = {"bus": bus, "scope": scope}
         if message_id:
             params["name"] = message_id
-        if slot is not None:
-            params["slot"] = slot
         response = await self._call("modem", "remove_sms", params)
         return dict(response)
 
@@ -130,9 +131,13 @@ class ModemModule(BaseModule):
         except NonZeroResponse:
             signals = {}
 
+        network_statuses, network_infos = await self._fetch_networks_49()
+
         modems: list[dict[str, Any]] = []
         for target in targets:
-            modem = await self._get_modem_49_status(target, signals)
+            modem = await self._get_modem_49_status(
+                target, signals, network_statuses, network_infos
+            )
             if modem is not None:
                 modems.append(modem)
         return {"modems": modems}
@@ -150,20 +155,46 @@ class ModemModule(BaseModule):
             return _deduplicate_targets(targets)
         return [{"bus": "cpu", "slot": 1}, {"bus": "cpu", "slot": 2}]
 
+    async def _fetch_networks_49(
+        self,
+    ) -> tuple[
+        dict[tuple[str, str], dict[str, Any]],
+        dict[tuple[str, str], dict[str, Any]],
+    ]:
+        try:
+            network_status_response = await self._call("modem", "get_network_status", {})
+        except NonZeroResponse:
+            network_status_response = {}
+        try:
+            network_info_response = await self._call("modem", "get_network_info", {})
+        except NonZeroResponse:
+            network_info_response = {}
+
+        return (
+            _index_networks_by_bus_slot(network_status_response),
+            _index_networks_by_bus_slot(network_info_response),
+        )
+
     async def _get_modem_49_status(
         self,
         target: dict[str, Any],
         signals: dict[str, dict[str, Any]],
+        network_statuses: dict[tuple[str, str], dict[str, Any]] | None = None,
+        network_infos: dict[tuple[str, str], dict[str, Any]] | None = None,
     ) -> dict[str, Any] | None:
-        params = dict(target)
-        try:
-            network_status_response = await self._call("modem", "get_network_status", params)
-            network_info_response = await self._call("modem", "get_network_info", params)
-        except NonZeroResponse:
-            return None
-
-        network_status = _first_dict(dict(network_status_response).get("networks"))
-        network_info = _first_dict(dict(network_info_response).get("networks"))
+        if network_statuses is not None and network_infos is not None:
+            network_status, network_info = _lookup_network_pair(
+                target, network_statuses, network_infos
+            )
+        else:
+            params = dict(target)
+            try:
+                network_status_response = await self._call("modem", "get_network_status", params)
+                network_info_response = await self._call("modem", "get_network_info", params)
+            except NonZeroResponse:
+                return None
+            network_status = _first_dict(dict(network_status_response).get("networks"))
+            network_info = _first_dict(dict(network_info_response).get("networks"))
         signal = signals.get(str(target.get("slot", "")), {})
         cell_info = dict(network_info.get("cell_info") or {})
         bus = str(network_status.get("bus") or network_info.get("bus") or target["bus"])
@@ -195,17 +226,38 @@ class ModemModule(BaseModule):
 
     async def _get_sms_list_49(self) -> list[dict[str, Any]]:
         targets = await self._get_modem_49_targets()
+        try:
+            network_statuses, network_infos = await self._fetch_networks_49()
+        except Exception:  # noqa: BLE001
+            network_statuses, network_infos = {}, {}
+
         messages: list[dict[str, Any]] = []
-        for bus in dict.fromkeys(str(target["bus"]) for target in targets):
-            try:
-                response = await self._call("modem", "get_sms_list", {"bus": bus})
-            except NonZeroResponse:
-                continue
-            if isinstance(response, list):
-                messages.extend(dict(item) for item in response)
-            else:
-                messages.extend(dict(item) for item in dict(response).get("list", []))
+        for target in targets:
+            bus_aliases = _bus_aliases(str(target.get("bus", "")))
+            network_info = _lookup_network_pair(target, network_statuses, network_infos)[1]
+            candidate_buses: list[str] = []
+            info_bus = network_info.get("bus")
+            if info_bus:
+                candidate_buses.append(str(info_bus))
+            candidate_buses.extend(bus_aliases)
+
+            seen: set[str] = set()
+            for bus in candidate_buses:
+                if not bus or bus in seen:
+                    continue
+                seen.add(bus)
+                response = await self._dispatch_sms_list_49(bus)
+                if response is None:
+                    continue
+                messages.extend(_flatten_sms_messages(response))
+                break
         return messages
+
+    async def _dispatch_sms_list_49(self, bus: str) -> Any:
+        try:
+            return await self._call("modem", "get_sms_list", {"bus": bus})
+        except NonZeroResponse:
+            return None
 
 
 def _targets_from_interface(interface: str) -> list[dict[str, Any]]:
@@ -226,11 +278,14 @@ def _targets_from_interface(interface: str) -> list[dict[str, Any]]:
         return [{"bus": "cpu", "slot": slot}]
 
     parts = [part for part in value.split("_") if part]
-    if len(parts) < 2:
+    if not parts:
         return []
-    bus = "-".join(parts[:2])
-    if len(parts) > 2:
-        bus = f"{bus}.{'.'.join(parts[2:])}"
+    if len(parts) == 1:
+        bus = parts[0]
+    else:
+        bus = "-".join(parts[:2])
+        if len(parts) > 2:
+            bus = f"{bus}.{'.'.join(parts[2:])}"
 
     target: dict[str, Any] = {"bus": bus}
     if slot is not None:
@@ -290,3 +345,84 @@ def _normalize_ip_info(value: Any) -> dict[str, Any]:
     if value not in (None, ""):
         return {"ip": str(value)}
     return {}
+
+
+def _target_lookup_key(target: dict[str, Any]) -> tuple[str, str]:
+    bus = str(target.get("bus", "") or "")
+    slot_value = target.get("slot")
+    slot = "" if slot_value is None else str(slot_value)
+    return bus, slot
+
+
+def _bus_aliases(bus: str) -> list[str]:
+    if not bus:
+        return [""]
+    aliases: list[str] = [bus]
+    if ":" in bus:
+        aliases.append(bus.split(":", 1)[0])
+    if "-" in bus and ":" not in bus:
+        head = bus.split(".", 1)[0]
+        aliases.append(head)
+    if bus.endswith(".0"):
+        aliases.append(bus[: -len(".0")])
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for alias in aliases:
+        if alias not in seen:
+            seen.add(alias)
+            deduped.append(alias)
+    return deduped
+
+
+def _lookup_network_pair(
+    target: dict[str, Any],
+    network_statuses: dict[tuple[str, str], dict[str, Any]],
+    network_infos: dict[tuple[str, str], dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    bus, slot = _target_lookup_key(target)
+    for alias in _bus_aliases(bus):
+        key = (alias, slot)
+        if key in network_statuses or key in network_infos:
+            return (
+                dict(network_statuses.get(key) or {}),
+                dict(network_infos.get(key) or {}),
+            )
+    return {}, {}
+
+
+def _flatten_sms_messages(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [dict(item) for item in response if isinstance(item, dict)]
+    if isinstance(response, dict):
+        raw = response.get("list", [])
+        if isinstance(raw, list):
+            return [dict(item) for item in raw if isinstance(item, dict)]
+    return []
+
+
+def _index_networks_by_bus_slot(
+    response: dict[str, Any] | list[Any],
+) -> dict[tuple[str, str], dict[str, Any]]:
+    payload: Any = response
+    if isinstance(payload, dict):
+        payload = payload.get("networks")
+    networks: list[Any]
+    if isinstance(payload, list):
+        networks = payload
+    else:
+        first = _first_dict(payload)
+        networks = [first] if first else []
+
+    indexed: dict[tuple[str, str], dict[str, Any]] = {}
+    for network in networks:
+        if not isinstance(network, dict):
+            continue
+        bus_value = network.get("bus")
+        slot_value = network.get("slot")
+        if bus_value is None or slot_value is None:
+            continue
+        slot_str = str(slot_value)
+        record = dict(network)
+        for alias in _bus_aliases(str(bus_value)):
+            indexed[(alias, slot_str)] = record
+    return indexed

--- a/custom_components/glinet_router/api/modules/modem.py
+++ b/custom_components/glinet_router/api/modules/modem.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..const import LONG_TIMEOUT
+from ..const import FIRMWARE_4_9, LONG_TIMEOUT
 from ..exceptions import NonZeroResponse
 from ..models import ModemInfo
 from .base import BaseModule
 
-FIRMWARE_4_9 = (4, 9, 0, 0)
-
 
 class ModemModule(BaseModule):
     async def get_status(self) -> dict[str, Any]:
-        if self._uses_modem_49_api:
+        if await self._uses_modem_49_api:
             return await self._get_status_49()
         response = await self._call("modem", "get_status")
         return dict(response)
 
     async def get_info(self) -> dict[str, Any]:
-        if self._uses_modem_49_api:
+        if await self._uses_modem_49_api:
             return await self._get_info_49()
         response = await self._call("modem", "get_info")
         return dict(response)
@@ -56,7 +54,7 @@ class ModemModule(BaseModule):
         ]
 
     async def get_sms_list(self) -> list[dict[str, Any]]:
-        if self._uses_modem_49_api:
+        if await self._uses_modem_49_api:
             return await self._get_sms_list_49()
         response = await self._call("modem", "get_sms_list")
         if isinstance(response, list):
@@ -107,9 +105,8 @@ class ModemModule(BaseModule):
         return dict(response)
 
     @property
-    def _uses_modem_49_api(self) -> bool:
-        firmware = self._client._firmware_version
-        return firmware is not None and firmware >= FIRMWARE_4_9
+    async def _uses_modem_49_api(self) -> bool:
+        return await self._client._is_firmware_at_least(FIRMWARE_4_9)
 
     async def _get_info_49(self) -> dict[str, Any]:
         status = await self._get_status_49()

--- a/custom_components/glinet_router/api/modules/modem.py
+++ b/custom_components/glinet_router/api/modules/modem.py
@@ -24,17 +24,17 @@ class ModemModule(BaseModule):
     async def get_modem_info(self) -> list[ModemInfo]:
         info_response = await self.get_info()
         status_response = await self.get_status()
-        
+
         info_modems = info_response.get("modems", [])
         status_modems = status_response.get("modems", [])
-        
+
         merged: dict[str, dict[str, Any]] = {}
         for modem in [*info_modems, *status_modems]:
             if not isinstance(modem, dict) or not modem.get("bus"):
                 continue
             bus = str(modem["bus"])
             merged[bus] = merged.get(bus, {}) | dict(modem)
-            
+
         return [
             ModemInfo(
                 bus=str(modem.get("bus", "")),
@@ -157,9 +157,7 @@ class ModemModule(BaseModule):
     ) -> dict[str, Any] | None:
         params = dict(target)
         try:
-            network_status_response = await self._call(
-                "modem", "get_network_status", params
-            )
+            network_status_response = await self._call("modem", "get_network_status", params)
             network_info_response = await self._call("modem", "get_network_info", params)
         except NonZeroResponse:
             return None

--- a/custom_components/glinet_router/api/modules/ovpn_client.py
+++ b/custom_components/glinet_router/api/modules/ovpn_client.py
@@ -24,7 +24,6 @@ class OvpnModule(BaseModule):
 
 
 class OvpnClientModule(BaseModule):
-
     def __init__(self, client: GLinetApiClient) -> None:
         super().__init__(client)
         self.ovpn_legacy = OvpnModule(client)
@@ -32,17 +31,17 @@ class OvpnClientModule(BaseModule):
 
     async def get_ovpn_clients(self) -> list[dict[str, Any]]:
         configs: list[dict[str, Any]] = []
-        
+
         groups_response = await self.ovpn_legacy.get_group_list()
         groups = dict(groups_response).get("groups", [])
-        
+
         for group in groups:
             group_id = group.get("group_id")
             group_name = group.get("group_name")
-            
+
             clients_response = await self.ovpn_legacy.get_config_list(group_id)
             clients = dict(clients_response).get("clients", [])
-            
+
             for client in clients:
                 configs.append(
                     {
@@ -56,25 +55,25 @@ class OvpnClientModule(BaseModule):
                         "raw_data": client,
                     }
                 )
-        
+
         tunnels_response = await self.vpn_client.get_tunnel()
         tunnels = dict(tunnels_response).get("tunnels", [])
-        
+
         ovpn_tunnel_id = None
         for tunnel in tunnels:
             if tunnel.get("via", {}).get("type") == "openvpn":
                 ovpn_tunnel_id = tunnel.get("tunnel_id")
                 break
-        
+
         if ovpn_tunnel_id is None:
-             for tunnel in tunnels:
-                 if tunnel.get("name") == "Primary Tunnel":
-                     ovpn_tunnel_id = tunnel.get("tunnel_id")
-                     break
+            for tunnel in tunnels:
+                if tunnel.get("name") == "Primary Tunnel":
+                    ovpn_tunnel_id = tunnel.get("tunnel_id")
+                    break
 
         for config in configs:
             config["tunnel_id"] = ovpn_tunnel_id
-            
+
         return configs
 
     async def get_status(self) -> list[dict[str, Any]]:
@@ -90,10 +89,10 @@ class OvpnClientModule(BaseModule):
                 if tunnel.get("via", {}).get("type") == "openvpn":
                     tunnel_id = tunnel.get("tunnel_id")
                     break
-        
+
         if tunnel_id is None:
-             raise ValueError("No OpenVPN tunnel found to start connection")
-            
+            raise ValueError("No OpenVPN tunnel found to start connection")
+
         return await self.vpn_client.set_tunnel(
             tunnel_id,
             True,
@@ -104,14 +103,14 @@ class OvpnClientModule(BaseModule):
         self, group_id: int, client_id: int, tunnel_id: int | None = None
     ) -> dict[str, Any]:
         if tunnel_id is None:
-             # Just find any active openvpn tunnel to stop it
-             status = await self.get_status()
-             for state in status:
-                 if state.get("type") == "openvpn" and state.get("status") == 1:
-                     tunnel_id = state.get("tunnel_id")
-                     break
-        
+            # Just find any active openvpn tunnel to stop it
+            status = await self.get_status()
+            for state in status:
+                if state.get("type") == "openvpn" and state.get("status") == 1:
+                    tunnel_id = state.get("tunnel_id")
+                    break
+
         if tunnel_id is None:
-             return {"ok": True} # Already stopped
-             
+            return {"ok": True}  # Already stopped
+
         return await self.vpn_client.set_tunnel(tunnel_id, False)

--- a/custom_components/glinet_router/api/modules/ovpn_server.py
+++ b/custom_components/glinet_router/api/modules/ovpn_server.py
@@ -7,6 +7,7 @@ from .base import BaseModule
 if TYPE_CHECKING:
     pass
 
+
 class OvpnServerModule(BaseModule):
     async def get_status(self) -> dict[str, Any]:
         response = await self._call("ovpn-server", "get_status")

--- a/custom_components/glinet_router/api/modules/system.py
+++ b/custom_components/glinet_router/api/modules/system.py
@@ -27,19 +27,15 @@ class SystemModule(BaseModule):
         response = await self._call("system", "get_status")
         status = dict(response)
         sys_info = status.get("system", {})
-        
+
         def _get(key, default=None):
             val = status.get(key)
             if val is None:
                 val = sys_info.get(key)
             return val if val is not None else default
 
-        load_average = (
-            _get("load_average") 
-            or _get("loadavg") 
-            or []
-        )
-        
+        load_average = _get("load_average") or _get("loadavg") or []
+
         cpu = status.get("cpu") or sys_info.get("cpu") or {}
         temperature = cpu.get("temperature")
         if temperature is None:

--- a/custom_components/glinet_router/api/modules/vpn_client.py
+++ b/custom_components/glinet_router/api/modules/vpn_client.py
@@ -17,8 +17,26 @@ class VpnClientModule(BaseModule):
     async def set_tunnel(
         self, tunnel_id: int, enabled: bool, via: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        params = {"enabled": enabled, "tunnel_id": tunnel_id}
+        params: dict[str, Any] = {"enabled": enabled, "tunnel_id": tunnel_id}
         if via:
             params["via"] = via
+        response = await self._call("vpn-client", "set_tunnel", params)
+        return dict(response)
+
+    async def set_tunnel_by_peer(
+        self,
+        enabled: bool,
+        tunnel_type: str,
+        group_id: int | None = None,
+        peer_id: int | None = None,
+        tunnel_id: int | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"enabled": enabled, "type": tunnel_type}
+        if group_id is not None:
+            params["group_id"] = group_id
+        if peer_id is not None:
+            params["peer_id"] = peer_id
+        if tunnel_id is not None:
+            params["tunnel_id"] = tunnel_id
         response = await self._call("vpn-client", "set_tunnel", params)
         return dict(response)

--- a/custom_components/glinet_router/api/modules/wg_client.py
+++ b/custom_components/glinet_router/api/modules/wg_client.py
@@ -8,6 +8,7 @@ from .base import BaseModule
 if TYPE_CHECKING:
     from ..client import GLinetApiClient
 
+
 class WireGuardModule(BaseModule):
     async def get_all_config_list(self) -> dict[str, Any]:
         response = await self._call("wg-client", "get_all_config_list")
@@ -47,8 +48,8 @@ class VpnClientModule(BaseModule):
         response = await self._call("vpn-client", "set_tunnel", params)
         return dict(response)
 
-class WgClientModule(BaseModule):
 
+class WgClientModule(BaseModule):
     def __init__(self, client: GLinetApiClient) -> None:
         super().__init__(client)
         self.wireguard = WireGuardModule(client)
@@ -80,14 +81,10 @@ class WgClientModule(BaseModule):
         response = await self.wireguard.get_status()
         return [dict(response)]
 
-    async def start_wireguard_client(
-        self, group_id: int, peer_id: int
-    ) -> dict[str, Any]:
+    async def start_wireguard_client(self, group_id: int, peer_id: int) -> dict[str, Any]:
         return await self._toggle_wireguard_client(group_id, peer_id, True)
 
-    async def stop_wireguard_client(
-        self, group_id: int, peer_id: int
-    ) -> dict[str, Any]:
+    async def stop_wireguard_client(self, group_id: int, peer_id: int) -> dict[str, Any]:
         return await self._toggle_wireguard_client(group_id, peer_id, False)
 
     async def _toggle_wireguard_client(

--- a/custom_components/glinet_router/api/modules/wg_client.py
+++ b/custom_components/glinet_router/api/modules/wg_client.py
@@ -24,6 +24,13 @@ class VpnClientModule(BaseModule):
         response = await self._call("vpn-client", "get_status")
         return dict(response)
 
+    async def get_tunnel(self) -> dict[str, Any]:
+        try:
+            response = await self._call("vpn-client", "get_tunnel")
+        except Exception:  # noqa: BLE001 - older firmware returns a router error
+            return {"tunnels": [], "default_tunnels": []}
+        return dict(response)
+
     async def set_tunnel(self, tunnel_id: int, enabled: bool) -> dict[str, Any]:
         response = await self._call(
             "vpn-client", "set_tunnel", {"enabled": enabled, "tunnel_id": tunnel_id}

--- a/custom_components/glinet_router/api/modules/wg_client.py
+++ b/custom_components/glinet_router/api/modules/wg_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..const import NEW_VPN_CLIENT_VERSION
+from ..const import FIRMWARE_4_9
 from .base import BaseModule
 
 if TYPE_CHECKING:
@@ -17,15 +17,6 @@ class WireGuardModule(BaseModule):
         response = await self._call("wg-client", "get_status")
         return dict(response)
 
-    async def start(self, group_id: int, peer_id: int) -> dict[str, Any]:
-        response = await self._call(
-            "wg-client", "start", {"group_id": group_id, "peer_id": peer_id}
-        )
-        return dict(response)
-
-    async def stop(self) -> dict[str, Any]:
-        response = await self._call("wg-client", "stop")
-        return dict(response)
 
 class VpnClientModule(BaseModule):
     async def get_status(self) -> dict[str, Any]:
@@ -36,6 +27,24 @@ class VpnClientModule(BaseModule):
         response = await self._call(
             "vpn-client", "set_tunnel", {"enabled": enabled, "tunnel_id": tunnel_id}
         )
+        return dict(response)
+
+    async def set_tunnel_by_peer(
+        self,
+        enabled: bool,
+        tunnel_type: str,
+        group_id: int | None = None,
+        peer_id: int | None = None,
+        tunnel_id: int | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"enabled": enabled, "type": tunnel_type}
+        if group_id is not None:
+            params["group_id"] = group_id
+        if peer_id is not None:
+            params["peer_id"] = peer_id
+        if tunnel_id is not None:
+            params["tunnel_id"] = tunnel_id
+        response = await self._call("vpn-client", "set_tunnel", params)
         return dict(response)
 
 class WgClientModule(BaseModule):
@@ -64,34 +73,32 @@ class WgClientModule(BaseModule):
         return configs
 
     async def get_wireguard_state(self) -> list[dict[str, Any]]:
-        if self._client._firmware_version is None:
-            await self._client.system.get_info()
-
-        fw_ver = self._client._firmware_version
-        if fw_ver is not None and fw_ver >= NEW_VPN_CLIENT_VERSION:
+        if await self._client._is_firmware_at_least(FIRMWARE_4_9):
             response = await self.vpn_client.get_status()
             return [dict(item) for item in dict(response).get("status_list", [])]
 
         response = await self.wireguard.get_status()
         return [dict(response)]
 
-    async def start_wireguard_client(self, group_id: int, peer_or_tunnel_id: int) -> dict[str, Any]:
-        return await self._toggle_wireguard_client(group_id, peer_or_tunnel_id, True)
+    async def start_wireguard_client(
+        self, group_id: int, peer_id: int
+    ) -> dict[str, Any]:
+        return await self._toggle_wireguard_client(group_id, peer_id, True)
 
-    async def stop_wireguard_client(self, peer_or_tunnel_id: int) -> dict[str, Any]:
-        return await self._toggle_wireguard_client(-1, peer_or_tunnel_id, False)
+    async def stop_wireguard_client(
+        self, group_id: int, peer_id: int
+    ) -> dict[str, Any]:
+        return await self._toggle_wireguard_client(group_id, peer_id, False)
 
     async def _toggle_wireguard_client(
-        self, group_id: int, peer_or_tunnel_id: int, enabled: bool
+        self, group_id: int, peer_id: int, enabled: bool
     ) -> dict[str, Any]:
-        if self._client._firmware_version is None:
-            await self._client.system.get_info()
+        if await self._client._is_firmware_at_least(FIRMWARE_4_9):
+            return await self.vpn_client.set_tunnel_by_peer(
+                enabled=enabled,
+                tunnel_type="wireguard",
+                group_id=group_id,
+                peer_id=peer_id,
+            )
 
-        fw_ver = self._client._firmware_version
-        if fw_ver is not None and fw_ver >= NEW_VPN_CLIENT_VERSION:
-            return await self.vpn_client.set_tunnel(peer_or_tunnel_id, enabled)
-
-        if enabled:
-            return await self.wireguard.start(group_id, peer_or_tunnel_id)
-
-        return await self.wireguard.stop()
+        return await self.vpn_client.set_tunnel(peer_id, enabled)

--- a/custom_components/glinet_router/api/modules/wg_server.py
+++ b/custom_components/glinet_router/api/modules/wg_server.py
@@ -7,8 +7,8 @@ from .base import BaseModule
 if TYPE_CHECKING:
     pass
 
-class WgServerModule(BaseModule):
 
+class WgServerModule(BaseModule):
     async def get_status(self) -> dict[str, Any]:
         response = await self._call("wg-server", "get_status")
         return dict(response)

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -140,11 +140,9 @@ def _config_schema(
 ) -> vol.Schema:
     defaults = defaults or {}
     wan_interfaces = wan_interfaces or DEFAULT_WAN_INTERFACES
-    selected_interfaces = _wan_interfaces_from_monitors(
-        defaults.get(CONF_WAN_STATUS_MONITORS, [])
-    )
+    selected_interfaces = _wan_interfaces_from_monitors(defaults.get(CONF_WAN_STATUS_MONITORS, []))
     wan_interfaces = [*dict.fromkeys([*wan_interfaces, *selected_interfaces])]
-    
+
     schema_dict = {
         vol.Required(CONF_HOST, default=DEFAULT_URL): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.URL)
@@ -236,7 +234,6 @@ STEP_USER_DATA_SCHEMA = _config_schema()
 
 
 class SetupHub:
-
     def __init__(self, host: str, hass: HomeAssistant) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
@@ -339,15 +336,12 @@ async def process_user_input(
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-
     VERSION = 1
 
     def __init__(self) -> None:
         self._discovered_data: dict[str, Any] | None = None
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
@@ -407,10 +401,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
         if user_input is not None:
             try:

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -20,12 +20,14 @@ from .const import (
     CONF_ADD_ALL_DEVICES,
     CONF_CLEANUP_DEVICES,
     CONF_ENABLED_FEATURES,
+    CONF_PARALLEL_REQUESTS,
     CONF_SCAN_INTERVAL,
     CONF_TITLE,
     CONF_UNKNOWN_DEVICES_FILTER_MANUAL,
     CONF_UNKNOWN_DEVICES_FILTER_MODE,
     CONF_UNKNOWN_DEVICES_FILTER_SELECT,
     CONF_WAN_STATUS_MONITORS,
+    DEFAULT_PARALLEL_REQUESTS,
     DEFAULT_PASSWORD,
     DEFAULT_UNKNOWN_DEVICES_FILTER_MODE,
     DEFAULT_URL,
@@ -150,6 +152,10 @@ def _config_schema(
         vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
+        vol.Optional(
+            CONF_PARALLEL_REQUESTS,
+            default=defaults.get(CONF_PARALLEL_REQUESTS, DEFAULT_PARALLEL_REQUESTS),
+        ): selector.BooleanSelector(),
         vol.Optional(
             CONF_CONSIDER_HOME,
             default=DEFAULT_CONSIDER_HOME.total_seconds(),
@@ -330,6 +336,10 @@ async def process_user_input(
             CONF_UNKNOWN_DEVICES_FILTER_MANUAL: data.get(
                 CONF_UNKNOWN_DEVICES_FILTER_MANUAL,
                 "",
+            ),
+            CONF_PARALLEL_REQUESTS: data.get(
+                CONF_PARALLEL_REQUESTS,
+                DEFAULT_PARALLEL_REQUESTS,
             ),
         },
     }

--- a/custom_components/glinet_router/const.py
+++ b/custom_components/glinet_router/const.py
@@ -63,6 +63,7 @@ SERVICE_GET_SMS = "get_sms"
 SERVICE_REMOVE_SMS = "remove_sms"
 SERVICE_REFRESH_SMS = "refresh_sms"
 SERVICE_SEND_SMS = "send_sms"
+SERVICE_REFRESH_CLIENTS = "refresh_clients"
 
 SERVICE_SCAN_WIFI = "scan_wifi"
 SERVICE_CONNECT_WIFI = "connect_wifi"

--- a/custom_components/glinet_router/const.py
+++ b/custom_components/glinet_router/const.py
@@ -13,6 +13,11 @@ CONF_WAN_STATUS_MONITORS = "wan_status_monitors"
 CONF_UNKNOWN_DEVICES_FILTER_MODE = "unknown_devices_filter_mode"
 CONF_UNKNOWN_DEVICES_FILTER_SELECT = "unknown_devices_filter_select"
 CONF_UNKNOWN_DEVICES_FILTER_MANUAL = "unknown_devices_filter_manual"
+# When True, the hub fires the per-feature fetches in parallel during a
+# coordinator refresh. The default (False) keeps the legacy sequential
+# behaviour so low-powered travel routers are not overwhelmed.
+CONF_PARALLEL_REQUESTS = "parallel_requests"
+DEFAULT_PARALLEL_REQUESTS = False
 DEFAULT_UNKNOWN_DEVICES_FILTER_MODE = "blacklist"
 
 WAN_INTERFACE_NAMES = {

--- a/custom_components/glinet_router/const.py
+++ b/custom_components/glinet_router/const.py
@@ -25,6 +25,8 @@ WAN_INTERFACE_NAMES = {
     "wwan": "Repeater",
     "tethering": "Tethering",
     "modem_0001": "Cellular",
+    "modem_0001_s1": "Cellular SIM 1",
+    "modem_0001_s2": "Cellular SIM 2",
     "secondwan": "Ethernet 2",
 }
 

--- a/custom_components/glinet_router/entities/binary_sensor.py
+++ b/custom_components/glinet_router/entities/binary_sensor.py
@@ -39,7 +39,6 @@ async def async_setup_entry(
 
 
 class RepeaterConnectedBinarySensor(CoordinatorEntity[GLinetHub], BinarySensorEntity):
-
     _attr_has_entity_name = True
     _attr_name = "Repeater connected"
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
@@ -80,7 +79,6 @@ class RepeaterConnectedBinarySensor(CoordinatorEntity[GLinetHub], BinarySensorEn
 
 
 class RepeaterBareModeBinarySensor(CoordinatorEntity[GLinetHub], BinarySensorEntity):
-
     _attr_has_entity_name = True
     _attr_translation_key = "repeater_bare_mode"
     _attr_icon = "mdi:wifi-off"

--- a/custom_components/glinet_router/entities/button.py
+++ b/custom_components/glinet_router/entities/button.py
@@ -99,6 +99,7 @@ class ScanWifiButton(CoordinatorEntity[GLinetHub], ButtonEntity):
     async def async_press(self) -> None:
         await self._hub.scan_wifi_networks()
 
+
 class TestFanButton(CoordinatorEntity[GLinetHub], ButtonEntity):
     _attr_has_entity_name = True
     _attr_name = "Fan test"

--- a/custom_components/glinet_router/entities/select.py
+++ b/custom_components/glinet_router/entities/select.py
@@ -43,7 +43,6 @@ async def async_setup_entry(
     if hub.feature_enabled(FEATURE_REPEATER):
         entities.extend([WifiNetworkSelect(hub), RepeaterBandSelect(hub)])
 
-
     async_add_entities(entities, True)
 
     if hub.feature_enabled(FEATURE_PARENTAL_CONTROL):
@@ -72,7 +71,6 @@ async def async_setup_entry(
 
 
 class WifiNetworkSelect(CoordinatorEntity[GLinetHub], SelectEntity):
-
     _attr_has_entity_name = True
     _attr_name = "WiFi network"
     _attr_icon = "mdi:wifi"
@@ -83,7 +81,6 @@ class WifiNetworkSelect(CoordinatorEntity[GLinetHub], SelectEntity):
         self._hub = hub
         self._attr_device_info = hub.device_info
         self._selected_ssid: str | None = None
-
 
     @property
     def unique_id(self) -> str:
@@ -183,7 +180,6 @@ class WifiNetworkSelect(CoordinatorEntity[GLinetHub], SelectEntity):
 
 
 class RepeaterBandSelect(CoordinatorEntity[GLinetHub], SelectEntity):
-
     _attr_has_entity_name = True
     _attr_name = "Repeater band"
     _attr_icon = "mdi:wifi-settings"
@@ -241,6 +237,3 @@ class GLinetClientParentalGroupSelect(CoordinatorEntity[GLinetHub], SelectEntity
         group = None if option == "None" else option
         await self._hub.assign_device_to_parental_group(self._device.mac, group)
         await self._hub.async_request_refresh()
-
-
-

--- a/custom_components/glinet_router/entities/sensor.py
+++ b/custom_components/glinet_router/entities/sensor.py
@@ -383,13 +383,9 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         has_entity_name=True,
         icon="mdi:email-alert",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda hub: sum(
-            1 for m in hub.sms_messages.values() if m.status == 0
-        ),
+        value_fn=lambda hub: sum(1 for m in hub.sms_messages.values() if m.status == 0),
         extra_attributes_fn=lambda hub: {
-            "unread_count": sum(
-                1 for m in hub.sms_messages.values() if m.status == 0
-            ),
+            "unread_count": sum(1 for m in hub.sms_messages.values() if m.status == 0),
             "message_count": len(hub.sms_messages),
             "incoming_count": sum(
                 1 for m in hub.sms_messages.values() if m.direction == "incoming"
@@ -563,10 +559,7 @@ def _sensor_is_enabled(hub: GLinetHub, description: HubSensorEntityDescription) 
         monitors = hub.wan_status_monitors
         protocol = "ipv4" if description.key == "cellular_ipv4" else "ipv6"
         if monitors is None:
-            return any(
-                iface.get("interface") == "modem_0001"
-                for iface in _wan_interfaces(hub)
-            )
+            return any(iface.get("interface") == "modem_0001" for iface in _wan_interfaces(hub))
         return f"modem_0001:{protocol}" in monitors
 
     feature = FEATURE_SENSOR_MAP.get(description.key)
@@ -993,7 +986,6 @@ class ClientSensor(CoordinatorEntity[GLinetHub], SensorEntity):
 
 
 class RepeaterChannelSensor(CoordinatorEntity[GLinetHub], SensorEntity):
-
     _attr_has_entity_name = True
     _attr_icon = "mdi:radio-tower"
     _attr_device_class = SensorDeviceClass.ENUM

--- a/custom_components/glinet_router/entities/sensor.py
+++ b/custom_components/glinet_router/entities/sensor.py
@@ -52,14 +52,13 @@ def _get_cellular_ip(hub: GLinetHub, version: str) -> str | None:
         if not isinstance(modem, dict):
             continue
         network = modem.get("network")
-        if not isinstance(network, dict):
-            continue
-        ip_info = network.get(version)
-        if not isinstance(ip_info, dict):
-            continue
-        ip = ip_info.get("ip")
-        if ip not in (None, ""):
-            return str(ip)
+        network_ip = network.get(version) if isinstance(network, dict) else None
+        for ip_info in (network_ip, modem.get(version)):
+            if not isinstance(ip_info, dict):
+                continue
+            ip = ip_info.get("ip")
+            if ip not in (None, ""):
+                return str(ip)
     return None
 
 
@@ -271,21 +270,6 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         value_fn=lambda hub: _battery_charging_status(hub),
     ),
     HubSensorEntityDescription(
-        key="cellular_signal",
-        name="Cellular signal",
-        has_entity_name=True,
-        icon="mdi:signal-cellular-2",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement="dBm",
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda hub: get_first_int(
-            hub.cellular_status,
-            ("signal", "signal_strength", "rssi", "rsrp", "csq"),
-            nested=("modem", "cellular", "sim", "signal"),
-        ),
-        extra_attributes_fn=lambda hub: hub.cellular_status,
-    ),
-    HubSensorEntityDescription(
         key="cellular_apn",
         name="Cellular APN",
         has_entity_name=True,
@@ -295,20 +279,6 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
             hub.cellular_status,
             ("apn",),
             nested=("modem", "cellular", "sim", "simcard"),
-        ),
-    ),
-    HubSensorEntityDescription(
-        key="cellular_rssi",
-        name="Cellular RSSI",
-        has_entity_name=True,
-        icon="mdi:signal-cellular-outline",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement="dBm",
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda hub: get_first_int(
-            hub.cellular_status,
-            ("rssi",),
-            nested=("modem", "cellular", "sim", "signal"),
         ),
     ),
     HubSensorEntityDescription(
@@ -362,18 +332,6 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
         value_fn=lambda hub: get_first_value(
             hub.cellular_status,
             ("band", "network_type", "service_type"),
-            nested=("modem", "cellular", "sim"),
-        ),
-    ),
-    HubSensorEntityDescription(
-        key="cellular_network",
-        name="Cellular network",
-        has_entity_name=True,
-        icon="mdi:signal-cellular-outline",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda hub: get_first_value(
-            hub.cellular_status,
-            ("network", "operator", "operator_name", "carrier", "mode", "service_type"),
             nested=("modem", "cellular", "sim"),
         ),
     ),
@@ -528,13 +486,10 @@ HUB_SENSORS: tuple[HubSensorEntityDescription, ...] = (
 )
 
 FEATURE_SENSOR_MAP: dict[str, str] = {
-    "cellular_signal": FEATURE_CELLULAR,
-    "cellular_rssi": FEATURE_CELLULAR,
     "cellular_rsrp": FEATURE_CELLULAR,
     "cellular_rsrq": FEATURE_CELLULAR,
     "cellular_sinr": FEATURE_CELLULAR,
     "cellular_band": FEATURE_CELLULAR,
-    "cellular_network": FEATURE_CELLULAR,
     "cellular_apn": FEATURE_CELLULAR,
     "sms_messages": FEATURE_SMS,
     "repeater_state": FEATURE_REPEATER,
@@ -693,6 +648,20 @@ def _wan_interface_label(interface_name: str) -> str:
 
 
 def _wan_interface_by_name(hub: GLinetHub, interface_name: str) -> dict[str, Any] | None:
+    if interface_name == "modem_0001" and getattr(hub, "is_firmware_4_9_or_above", False):
+        for candidate in ("modem_0001_s1", "modem_0001_s2"):
+            entry = _wan_lookup_exact(hub, candidate)
+            if entry is not None and entry.get("status_v4") == 0:
+                return entry
+        for candidate in ("modem_0001_s1", "modem_0001_s2"):
+            entry = _wan_lookup_exact(hub, candidate)
+            if entry is not None:
+                return entry
+        return None
+    return _wan_lookup_exact(hub, interface_name)
+
+
+def _wan_lookup_exact(hub: GLinetHub, interface_name: str) -> dict[str, Any] | None:
     for interface in _wan_interfaces(hub):
         if interface.get("interface") == interface_name:
             return interface
@@ -928,9 +897,16 @@ class WanStatusSensor(CoordinatorEntity[GLinetHub], SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         interface = _wan_interface_by_name(self.hub, self._interface_name) or {}
+        resolved_interface_name = str(interface.get("interface") or self._interface_name)
+        resolved_label = (
+            _wan_interface_label(resolved_interface_name)
+            if resolved_interface_name != self._interface_name
+            else self._interface_label
+        )
         return {
-            "interface": self._interface_name,
-            "interface_name": self._interface_label,
+            "interface": resolved_interface_name,
+            "interface_name": resolved_label,
+            "requested_interface": self._interface_name,
             "monitored_protocols": sorted(self._protocols),
             "ipv4_status": _wan_protocol_status(interface, "ipv4"),
             "ipv6_status": _wan_protocol_status(interface, "ipv6"),

--- a/custom_components/glinet_router/entities/switch.py
+++ b/custom_components/glinet_router/entities/switch.py
@@ -73,8 +73,7 @@ async def async_setup_entry(
     if hub.feature_enabled(FEATURE_PARENTAL_CONTROL):
         entities.append(GLinetParentalControlGlobalSwitch(hub))
         entities.extend(
-            GLinetParentalControlGroupSwitch(hub, group)
-            for group in hub.parental_groups.values()
+            GLinetParentalControlGroupSwitch(hub, group) for group in hub.parental_groups.values()
         )
     entities.append(LedSwitch(hub))
     async_add_entities(entities, True)
@@ -163,7 +162,6 @@ class WifiApSwitch(GLinetSwitchBase):
         await self._hub.async_request_refresh()
 
 
-
 class TailscaleSwitch(GLinetSwitchBase):
     _attr_icon = "mdi:vpn"
 
@@ -203,12 +201,14 @@ class TailscaleSwitch(GLinetSwitchBase):
             return
         await self._hub.async_request_refresh()
 
+
 class WireGuardSwitch(GLinetSwitchBase):
     _attr_icon = "mdi:vpn"
 
     def __init__(self, hub: GLinetHub, client: WireGuardClient) -> None:
         super().__init__(hub)
         self._client = client
+
     @property
     def unique_id(self) -> str:
         return f"glinet_switch/{self._hub.device_mac}/{self._client.name}/wireguard_client"
@@ -288,7 +288,6 @@ class WireGuardServerSwitch(GLinetSwitchBase):
             return
         await asyncio.sleep(10)
         await self._hub.async_request_refresh()
-
 
 
 class RepeaterAutoSwitchSwitch(GLinetSwitchBase):
@@ -397,7 +396,7 @@ class OpenVpnClientSwitch(GLinetSwitchBase):
     def name(self) -> str:
         name = f"OpenVPN {self._client.name}"
         if self._client.group_name:
-             name = f"OpenVPN {self._client.group_name} {self._client.name}"
+            name = f"OpenVPN {self._client.group_name} {self._client.name}"
         return name
 
     @property

--- a/custom_components/glinet_router/entities/switch.py
+++ b/custom_components/glinet_router/entities/switch.py
@@ -10,6 +10,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..const import (
@@ -26,7 +27,15 @@ from ..const import (
     FEATURE_ZEROTIER,
 )
 from ..hub import GLinetHub
-from ..models import ClientDeviceInfo, OpenVpnClient, ParentalGroup, WifiInterface, WireGuardClient
+from ..models import (
+    ClientDeviceInfo,
+    OpenVpnClient,
+    ParentalGroup,
+    VpnTunnel,
+    VpnTunnelType,
+    WifiInterface,
+    WireGuardClient,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -41,12 +50,40 @@ async def async_setup_entry(
 ) -> None:
     hub: GLinetHub = entry.runtime_data
     entities: list[SwitchEntity] = []
-    if hub.feature_enabled(FEATURE_WG_CLIENT):
-        entities.extend(WireGuardSwitch(hub, client) for client in hub.vpn_clients.values())
+    # 4.9+ exposes a unified VPN dashboard. When tunnels are present we
+    # surface those as switches instead of the per-profile entries from 4.8.
+    dashboard_tunnels: list[VpnTunnel] = []
+    if hub.feature_enabled(FEATURE_WG_CLIENT) or hub.feature_enabled(FEATURE_OVPN_CLIENT):
+        for tunnel in hub.vpn_tunnels.values():
+            if tunnel.tunnel_type == VpnTunnelType.WIREGUARD and hub.feature_enabled(
+                FEATURE_WG_CLIENT
+            ):
+                dashboard_tunnels.append(tunnel)
+            elif tunnel.tunnel_type == VpnTunnelType.OPENVPN and hub.feature_enabled(
+                FEATURE_OVPN_CLIENT
+            ):
+                dashboard_tunnels.append(tunnel)
+            elif tunnel.tunnel_type == VpnTunnelType.UNKNOWN:
+                # Show unknown-typed tunnels if either client feature is on;
+                # the user can still toggle them via the dashboard.
+                if hub.feature_enabled(
+                    FEATURE_WG_CLIENT
+                ) or hub.feature_enabled(FEATURE_OVPN_CLIENT):
+                    dashboard_tunnels.append(tunnel)
+
+    if dashboard_tunnels:
+        entities.extend(VpnTunnelSwitch(hub, tunnel) for tunnel in dashboard_tunnels)
+    else:
+        if hub.feature_enabled(FEATURE_WG_CLIENT):
+            entities.extend(
+                WireGuardSwitch(hub, client) for client in hub.vpn_clients.values()
+            )
+        if hub.feature_enabled(FEATURE_OVPN_CLIENT):
+            entities.extend(
+                OpenVpnClientSwitch(hub, client) for client in hub.ovpn_clients.values()
+            )
     if hub.feature_enabled(FEATURE_WG_SERVER):
         entities.append(WireGuardServerSwitch(hub))
-    if hub.feature_enabled(FEATURE_OVPN_CLIENT):
-        entities.extend(OpenVpnClientSwitch(hub, client) for client in hub.ovpn_clients.values())
     if hub.feature_enabled(FEATURE_OVPN_SERVER):
         entities.append(OpenVpnServerSwitch(hub))
     if hub.has_tailscale and hub.feature_enabled(FEATURE_TAILSCALE):
@@ -77,6 +114,97 @@ async def async_setup_entry(
         )
     entities.append(LedSwitch(hub))
     async_add_entities(entities, True)
+
+    # ------------------------------------------------------------------
+    # Live reconciliation for VPN dashboard tunnels (4.9+)
+    # ------------------------------------------------------------------
+    # When a profile is removed from the router, the corresponding tunnel
+    # disappears from `vpn-client.get_tunnel`. The hub dispatches the
+    # ``event_vpn_tunnels_updated`` event after every fetch with the new set
+    # of tunnel ids, so we use it to add new switches and remove stale ones
+    # automatically. This keeps Home Assistant in lockstep with whatever is
+    # currently configured on the router.
+    # VpnTunnelSwitch is defined further down in this module; the type
+    # annotation has to be a string here because of the forward reference.
+    vpn_tunnel_switches: "dict[int, VpnTunnelSwitch]" = {  # noqa: UP037
+        entity._tunnel_id: entity
+        for entity in entities
+        if isinstance(entity, VpnTunnelSwitch)
+    }
+
+    def _candidate_tunnels_for_features() -> list[VpnTunnel]:
+        result: list[VpnTunnel] = []
+        for tunnel in hub.vpn_tunnels.values():
+            if tunnel.tunnel_type == VpnTunnelType.WIREGUARD and hub.feature_enabled(
+                FEATURE_WG_CLIENT
+            ):
+                result.append(tunnel)
+            elif tunnel.tunnel_type == VpnTunnelType.OPENVPN and hub.feature_enabled(
+                FEATURE_OVPN_CLIENT
+            ):
+                result.append(tunnel)
+            elif tunnel.tunnel_type == VpnTunnelType.UNKNOWN and (
+                hub.feature_enabled(FEATURE_WG_CLIENT)
+                or hub.feature_enabled(FEATURE_OVPN_CLIENT)
+            ):
+                result.append(tunnel)
+        return result
+
+    @callback
+    def _reconcile_vpn_tunnels(current_ids: set[int] | None = None) -> None:
+        hass = hub.hass
+        hass.async_create_task(_async_reconcile_vpn_tunnels(current_ids))
+
+    async def _async_reconcile_vpn_tunnels(
+        current_ids: set[int] | None = None,
+    ) -> None:
+        if current_ids is None:
+            current_ids = {t.tunnel_id for t in _candidate_tunnels_for_features()}
+
+        existing_ids = set(vpn_tunnel_switches.keys())
+
+        # Add new tunnels that have appeared since the last fetch.
+        new_tunnels = [
+            tunnel
+            for tunnel in _candidate_tunnels_for_features()
+            if tunnel.tunnel_id not in existing_ids
+            and tunnel.tunnel_id in current_ids
+        ]
+        if new_tunnels:
+            new_entities = [VpnTunnelSwitch(hub, tunnel) for tunnel in new_tunnels]
+            for entity in new_entities:
+                vpn_tunnel_switches[entity._tunnel_id] = entity
+            async_add_entities(new_entities, True)
+
+        # Remove tunnels that disappeared from the router.
+        stale_ids = existing_ids - current_ids
+        if stale_ids:
+            registry = async_get_entity_registry(hub.hass)
+            for stale_id in list(stale_ids):
+                entity = vpn_tunnel_switches.pop(stale_id, None)
+                if entity is None:
+                    continue
+                # ``Entity.async_remove`` is a coroutine; it must be
+                # awaited for the entity to be detached from the platform.
+                # ``force_remove=True`` clears the entity state immediately
+                # rather than marking it as unavailable.
+                await entity.async_remove(force_remove=True)
+                # ``Entity.async_remove`` only removes the state — the
+                # entry in the Entity Registry survives unless we also
+                # drop it. Without this, the user still sees the entity
+                # (with state "unavailable") and cannot delete it from
+                # the UI. Removing the registry entry makes the entity
+                # disappear from Home Assistant completely.
+                if entity.entity_id:
+                    registry.async_remove(entity.entity_id)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hub.hass,
+            hub.event_vpn_tunnels_updated,
+            _reconcile_vpn_tunnels,
+        )
+    )
 
     if hub.feature_enabled(FEATURE_PARENTAL_CONTROL):
         tracked: set[str] = set()
@@ -428,6 +556,86 @@ class OpenVpnClientSwitch(GLinetSwitchBase):
             _LOGGER.exception("Unable to stop OpenVPN client")
             return
         await asyncio.sleep(10)
+        await self._hub.async_request_refresh()
+
+
+class VpnTunnelSwitch(GLinetSwitchBase):
+
+    _attr_icon = "mdi:vpn"
+
+    def __init__(self, hub: GLinetHub, tunnel: VpnTunnel) -> None:
+        super().__init__(hub)
+        self._tunnel_id = tunnel.tunnel_id
+        self._tunnel_type = tunnel.tunnel_type
+        self._cached_tunnel = tunnel
+
+    def _current_tunnel(self) -> VpnTunnel | None:
+        tunnel = self._hub.vpn_tunnels.get(self._tunnel_id)
+        if tunnel is not None:
+            self._cached_tunnel = tunnel
+        return tunnel
+
+    @property
+    def _tunnel(self) -> VpnTunnel:
+        return self._current_tunnel() or self._cached_tunnel
+
+    @property
+    def unique_id(self) -> str:
+        if self._tunnel_type in {VpnTunnelType.WIREGUARD, VpnTunnelType.OPENVPN}:
+            type_token = (
+                "wg" if self._tunnel_type == VpnTunnelType.WIREGUARD else "ovpn"
+            )
+            return (
+                f"glinet_switch/{self._hub.device_mac}"
+                f"/vpn_tunnel/{type_token}/{self._tunnel_id}"
+            )
+        # Unknown type - keep the tunnel prefix so both WG and OVPN feature
+        # cleanup can find it if either feature is later disabled.
+        return (
+            f"glinet_switch/{self._hub.device_mac}"
+            f"/vpn_tunnel/unknown/{self._tunnel_id}"
+        )
+
+    @property
+    def name(self) -> str:
+        tunnel = self._tunnel
+        tunnel_name = tunnel.name or f"Tunnel {self._tunnel_id}"
+        if self._tunnel_type == VpnTunnelType.WIREGUARD:
+            return f"WG Tunnel {tunnel_name}"
+        if self._tunnel_type == VpnTunnelType.OPENVPN:
+            return f"OpenVPN Tunnel {tunnel_name}"
+        return f"VPN Tunnel {tunnel_name}"
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._tunnel.enabled
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        tunnel = self._tunnel
+        return {
+            "tunnel_id": tunnel.tunnel_id,
+            "tunnel_type": tunnel.tunnel_type.value,
+            "connected": tunnel.connected,
+            "killswitch": tunnel.killswitch,
+            "is_default": tunnel.is_default,
+            "via": tunnel.via,
+        }
+
+    async def async_turn_on(self, **_: Any) -> None:
+        try:
+            await self._hub.set_vpn_tunnel(self._tunnel_id, True)
+        except OSError:
+            _LOGGER.exception("Unable to enable VPN tunnel %s", self._tunnel_id)
+            return
+        await self._hub.async_request_refresh()
+
+    async def async_turn_off(self, **_: Any) -> None:
+        try:
+            await self._hub.set_vpn_tunnel(self._tunnel_id, False)
+        except OSError:
+            _LOGGER.exception("Unable to disable VPN tunnel %s", self._tunnel_id)
+            return
         await self._hub.async_request_refresh()
 
 

--- a/custom_components/glinet_router/entities/switch.py
+++ b/custom_components/glinet_router/entities/switch.py
@@ -66,18 +66,16 @@ async def async_setup_entry(
             elif tunnel.tunnel_type == VpnTunnelType.UNKNOWN:
                 # Show unknown-typed tunnels if either client feature is on;
                 # the user can still toggle them via the dashboard.
-                if hub.feature_enabled(
-                    FEATURE_WG_CLIENT
-                ) or hub.feature_enabled(FEATURE_OVPN_CLIENT):
+                if hub.feature_enabled(FEATURE_WG_CLIENT) or hub.feature_enabled(
+                    FEATURE_OVPN_CLIENT
+                ):
                     dashboard_tunnels.append(tunnel)
 
     if dashboard_tunnels:
         entities.extend(VpnTunnelSwitch(hub, tunnel) for tunnel in dashboard_tunnels)
     else:
         if hub.feature_enabled(FEATURE_WG_CLIENT):
-            entities.extend(
-                WireGuardSwitch(hub, client) for client in hub.vpn_clients.values()
-            )
+            entities.extend(WireGuardSwitch(hub, client) for client in hub.vpn_clients.values())
         if hub.feature_enabled(FEATURE_OVPN_CLIENT):
             entities.extend(
                 OpenVpnClientSwitch(hub, client) for client in hub.ovpn_clients.values()
@@ -127,9 +125,7 @@ async def async_setup_entry(
     # VpnTunnelSwitch is defined further down in this module; the type
     # annotation has to be a string here because of the forward reference.
     vpn_tunnel_switches: "dict[int, VpnTunnelSwitch]" = {  # noqa: UP037
-        entity._tunnel_id: entity
-        for entity in entities
-        if isinstance(entity, VpnTunnelSwitch)
+        entity._tunnel_id: entity for entity in entities if isinstance(entity, VpnTunnelSwitch)
     }
 
     def _candidate_tunnels_for_features() -> list[VpnTunnel]:
@@ -144,8 +140,7 @@ async def async_setup_entry(
             ):
                 result.append(tunnel)
             elif tunnel.tunnel_type == VpnTunnelType.UNKNOWN and (
-                hub.feature_enabled(FEATURE_WG_CLIENT)
-                or hub.feature_enabled(FEATURE_OVPN_CLIENT)
+                hub.feature_enabled(FEATURE_WG_CLIENT) or hub.feature_enabled(FEATURE_OVPN_CLIENT)
             ):
                 result.append(tunnel)
         return result
@@ -167,8 +162,7 @@ async def async_setup_entry(
         new_tunnels = [
             tunnel
             for tunnel in _candidate_tunnels_for_features()
-            if tunnel.tunnel_id not in existing_ids
-            and tunnel.tunnel_id in current_ids
+            if tunnel.tunnel_id not in existing_ids and tunnel.tunnel_id in current_ids
         ]
         if new_tunnels:
             new_entities = [VpnTunnelSwitch(hub, tunnel) for tunnel in new_tunnels]
@@ -560,7 +554,6 @@ class OpenVpnClientSwitch(GLinetSwitchBase):
 
 
 class VpnTunnelSwitch(GLinetSwitchBase):
-
     _attr_icon = "mdi:vpn"
 
     def __init__(self, hub: GLinetHub, tunnel: VpnTunnel) -> None:
@@ -582,19 +575,11 @@ class VpnTunnelSwitch(GLinetSwitchBase):
     @property
     def unique_id(self) -> str:
         if self._tunnel_type in {VpnTunnelType.WIREGUARD, VpnTunnelType.OPENVPN}:
-            type_token = (
-                "wg" if self._tunnel_type == VpnTunnelType.WIREGUARD else "ovpn"
-            )
-            return (
-                f"glinet_switch/{self._hub.device_mac}"
-                f"/vpn_tunnel/{type_token}/{self._tunnel_id}"
-            )
+            type_token = "wg" if self._tunnel_type == VpnTunnelType.WIREGUARD else "ovpn"
+            return f"glinet_switch/{self._hub.device_mac}/vpn_tunnel/{type_token}/{self._tunnel_id}"
         # Unknown type - keep the tunnel prefix so both WG and OVPN feature
         # cleanup can find it if either feature is later disabled.
-        return (
-            f"glinet_switch/{self._hub.device_mac}"
-            f"/vpn_tunnel/unknown/{self._tunnel_id}"
-        )
+        return f"glinet_switch/{self._hub.device_mac}/vpn_tunnel/unknown/{self._tunnel_id}"
 
     @property
     def name(self) -> str:

--- a/custom_components/glinet_router/entities/switch.py
+++ b/custom_components/glinet_router/entities/switch.py
@@ -232,11 +232,11 @@ class WireGuardSwitch(GLinetSwitchBase):
                 and self._client not in self._hub.connected_vpn_clients
             ):
                 for client in self._hub.connected_vpn_clients:
-                    await self._hub.stop_vpn_client(client.peer_id)
+                    await self._hub.stop_vpn_client(client.group_id, client.peer_id)
 
             await self._hub.start_vpn_client(
                 self._client.group_id,
-                self._client.tunnel_id or self._client.peer_id,
+                self._client.peer_id,
             )
         except OSError:
             _LOGGER.exception("Unable to enable WireGuard client")
@@ -246,7 +246,8 @@ class WireGuardSwitch(GLinetSwitchBase):
     async def async_turn_off(self, **_: Any) -> None:
         try:
             await self._hub.stop_vpn_client(
-                self._client.tunnel_id or self._client.peer_id
+                self._client.group_id,
+                self._client.peer_id,
             )
         except OSError:
             _LOGGER.exception("Unable to stop WireGuard client")

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -1041,9 +1041,9 @@ class GLinetHub(DataUpdateCoordinator[None]):
         )
         await self.fetch_wireguard_clients()
 
-    async def stop_vpn_client(self, peer_id: int) -> None:
+    async def stop_vpn_client(self, group_id: int, peer_id: int) -> None:
         await self._invoke_api(
-            lambda: self.router_api.wg_client.stop_wireguard_client(peer_id)
+            lambda: self.router_api.wg_client.stop_wireguard_client(group_id, peer_id)
         )
         await self.fetch_wireguard_clients()
 

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -301,7 +301,6 @@ class GLinetHub(DataUpdateCoordinator[None]):
                 removed = True
 
             if not removed:
-
                 mac = None
                 if entry.domain == TRACKER_DOMAIN:
                     mac = entry.unique_id
@@ -770,9 +769,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
         await self.get_mcu_oled_config()
 
     async def fetch_access_control_config(self) -> None:
-        response = await self._invoke_optional_api(
-            self.router_api.black_white_list.get_config
-        )
+        response = await self._invoke_optional_api(self.router_api.black_white_list.get_config)
         self._access_control_config = response or {}
         self._access_control_mode = str(
             self._access_control_config.get("mode")
@@ -797,9 +794,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
         self._parental_status = ParentalStatus.from_api_response(config, status, mode)
 
     async def set_parental_control_enabled(self, enabled: bool) -> None:
-        await self._invoke_api(
-            lambda: self.router_api.parental_control.set_config(enabled)
-        )
+        await self._invoke_api(lambda: self.router_api.parental_control.set_config(enabled))
         await self.fetch_parental_control_status()
 
     async def set_group_enabled(self, group_id: str, enabled: bool) -> None:
@@ -838,9 +833,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
     async def set_access_control_mode(self, mode: str) -> None:
         macs = self._white_mac if mode == "white" else self._black_mac
-        await self._invoke_api(
-            lambda: self.router_api.black_white_list.set_config(mode, macs)
-        )
+        await self._invoke_api(lambda: self.router_api.black_white_list.set_config(mode, macs))
         await self.fetch_access_control_config()
 
     async def set_single_device_block(self, mac: str, block: bool) -> None:
@@ -858,9 +851,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
     async def set_group_schedules_enabled(self, group_id: str, enabled: bool) -> None:
         group = self._parental_status.groups.get(group_id)
         params = (
-            group.with_updates(schedule_enable=enabled, schedules_enabled=enabled)
-            if group
-            else {}
+            group.with_updates(schedule_enable=enabled, schedules_enabled=enabled) if group else {}
         )
         params.pop("id", None)
         await self._invoke_api(
@@ -1007,9 +998,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
                 group_id=int(config["group_id"]),
                 peer_id=int(config["peer_id"]),
                 tunnel_id=(
-                    int(config["tunnel_id"])
-                    if config.get("tunnel_id") is not None
-                    else None
+                    int(config["tunnel_id"]) if config.get("tunnel_id") is not None else None
                 ),
             )
             for config in response
@@ -1075,7 +1064,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
             locations = []
             if config.get("location"):
                 locations = [loc.strip() for loc in config["location"].split(";")]
-            
+
             remotes = []
             remote_val = config.get("remote")
             if isinstance(remote_val, list):
@@ -1128,7 +1117,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
     async def start_ovpn_client(self, group_id: int, client_id: int) -> None:
         # Match sample project: stop active OpenVPN first
         await self.stop_all_ovpns()
-        
+
         key = f"{group_id}_{client_id}"
         client = self._ovpn_clients.get(key)
         tunnel_id = client.tunnel_id if client else None
@@ -1163,7 +1152,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
             self._ovpn_server_status = {}
             return
         self._ovpn_server_status = status_response
-        
+
         users_response = await self._invoke_api(self.router_api.ovpn_server.get_user_list)
         self._ovpn_server_users = users_response or []
 
@@ -1233,9 +1222,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
             self._led_enabled = response.get("led_enable")
 
     async def set_led_enabled(self, enabled: bool) -> None:
-        await self._invoke_api(
-            lambda: self.router_api.led.set_config({"led_enable": enabled})
-        )
+        await self._invoke_api(lambda: self.router_api.led.set_config({"led_enable": enabled}))
         await self.fetch_led_status()
 
     async def fetch_adguard_status(self) -> None:
@@ -1272,15 +1259,9 @@ class GLinetHub(DataUpdateCoordinator[None]):
             dict(info_response or {}).get("modems", []),
             dict(status_response or {}).get("modems", []),
         )
-        self._modems = {
-            _modem_key(modem): modem
-            for modem in modems
-            if modem.get("bus")
-        }
+        self._modems = {_modem_key(modem): modem for modem in modems if modem.get("bus")}
         default_modem = _select_sms_modem(self._modems)
-        self._default_modem_bus = (
-            str(default_modem.get("bus")) if default_modem else None
-        )
+        self._default_modem_bus = str(default_modem.get("bus")) if default_modem else None
         self._default_modem_slot = default_modem.get("slot") if default_modem else None
         self._cellular_status = {
             "modems": modems,
@@ -1301,9 +1282,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
             self._repeater_config = response
 
     async def set_repeater_auto_switch(self, enabled: bool) -> None:
-        await self._invoke_api(
-            lambda: self.router_api.repeater.set_config({"auto": enabled})
-        )
+        await self._invoke_api(lambda: self.router_api.repeater.set_config({"auto": enabled}))
         await self.fetch_repeater_config()
 
     async def set_repeater_smart_reconnect(self, enabled: bool) -> None:
@@ -1320,9 +1299,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
         await self.fetch_repeater_status()
 
     async def set_repeater_band(self, band: str | None) -> None:
-        await self._invoke_api(
-            lambda: self.router_api.repeater.set_config({"lock_band": band})
-        )
+        await self._invoke_api(lambda: self.router_api.repeater.set_config({"lock_band": band}))
         await self.fetch_repeater_config()
 
     async def fetch_fan_status(self) -> None:
@@ -1390,9 +1367,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
             params["key"] = password
         if bssid:
             params["bssid"] = bssid
-        await self._invoke_api(
-            lambda: self.router_api.repeater.connect(params)
-        )
+        await self._invoke_api(lambda: self.router_api.repeater.connect(params))
         await self.fetch_repeater_status()
 
     async def disconnect_wifi(self) -> None:
@@ -1458,9 +1433,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
             else:
 
                 async def api_call(c: str = chunk):
-                    return await self.router_api.modem.send_sms(
-                        bus, recipient, c, slot=slot
-                    )
+                    return await self.router_api.modem.send_sms(bus, recipient, c, slot=slot)
 
             response = await self._invoke_optional_api(api_call)
             if response is None:
@@ -1468,9 +1441,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
         await self.fetch_sms_messages()
 
-    async def remove_sms(
-        self, scope: int, message_id: str | None = None
-    ) -> None:
+    async def remove_sms(self, scope: int, message_id: str | None = None) -> None:
         message = self._sms_messages.get(message_id) if message_id else None
         bus = message.bus if message else self._default_modem_bus
         slot = (
@@ -1494,9 +1465,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
         else:
 
             async def api_call():
-                return await self.router_api.modem.remove_sms(
-                    bus, scope, message_id, slot=slot
-                )
+                return await self.router_api.modem.remove_sms(bus, scope, message_id, slot=slot)
 
         await self._invoke_optional_api(api_call)
         if scope == 10 and message_id:
@@ -1556,10 +1525,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
     async def custom_request(
         self, method: str, body: dict[str, Any] | list[Any] | None = None
     ) -> dict[str, Any] | list[Any] | None:
-        return await self._invoke_api(
-            lambda: self.router_api.custom_call(method, body)
-        )
-
+        return await self._invoke_api(lambda: self.router_api.custom_call(method, body))
 
     @property
     def router_host(self) -> str:
@@ -1679,30 +1645,22 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
     @property
     def current_traffic_download(self) -> int:
-        return sum(
-            get_first_int(d, ("rx",)) or 0
-            for d in self._all_connected_clients.values()
-        )
+        return sum(get_first_int(d, ("rx",)) or 0 for d in self._all_connected_clients.values())
 
     @property
     def current_traffic_upload(self) -> int:
-        return sum(
-            get_first_int(d, ("tx",)) or 0
-            for d in self._all_connected_clients.values()
-        )
+        return sum(get_first_int(d, ("tx",)) or 0 for d in self._all_connected_clients.values())
 
     @property
     def total_traffic_download(self) -> int:
         return sum(
-            get_first_int(d, ("total_rx",)) or 0
-            for d in self._all_connected_clients.values()
+            get_first_int(d, ("total_rx",)) or 0 for d in self._all_connected_clients.values()
         )
 
     @property
     def total_traffic_upload(self) -> int:
         return sum(
-            get_first_int(d, ("total_tx",)) or 0
-            for d in self._all_connected_clients.values()
+            get_first_int(d, ("total_tx",)) or 0 for d in self._all_connected_clients.values()
         )
 
     @property
@@ -1864,6 +1822,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
     def event_networks_updated(self) -> str:
         return f"{DOMAIN}-networks-update-{self._factory_mac}"
 
+
 def _merge_modem_lists(
     info_modems: list[dict[str, Any]],
     status_modems: list[dict[str, Any]],
@@ -1926,5 +1885,3 @@ def _access_mode_is_black(mode: str) -> bool:
 
 def _access_mode_is_white(mode: str) -> bool:
     return mode in {"white", "whitelist", "allow"}
-
-

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -41,11 +42,13 @@ from .const import (
     CONF_ADD_ALL_DEVICES,
     CONF_CLEANUP_DEVICES,
     CONF_ENABLED_FEATURES,
+    CONF_PARALLEL_REQUESTS,
     CONF_SCAN_INTERVAL,
     CONF_UNKNOWN_DEVICES_FILTER_MANUAL,
     CONF_UNKNOWN_DEVICES_FILTER_MODE,
     CONF_UNKNOWN_DEVICES_FILTER_SELECT,
     CONF_WAN_STATUS_MONITORS,
+    DEFAULT_PARALLEL_REQUESTS,
     DEFAULT_USERNAME,
     DOMAIN,
     FEATURE_ADGUARD,
@@ -76,6 +79,7 @@ from .models import (
     RepeaterStatus,
     ScannedNetwork,
     SmsMessage,
+    VpnTunnel,
     WifiInterface,
     WireGuardClient,
     WireGuardServerStatus,
@@ -127,6 +131,8 @@ class GLinetHub(DataUpdateCoordinator[None]):
         self._default_modem_slot: int | str | None = None
         self._wireguard_clients: dict[int, WireGuardClient] = {}
         self._wireguard_connections: list[WireGuardClient] | None = None
+        self._vpn_tunnels: dict[int, VpnTunnel] = {}
+        self._vpn_tunnel_connections: list[VpnTunnel] | None = None
         self._tailscale_config: dict[str, Any] = {}
         self._tailscale_connection: bool | None = None
         self._sms_messages: dict[str, SmsMessage] = {}
@@ -182,6 +188,12 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
     def feature_enabled(self, feature: str) -> bool:
         return feature in self.enabled_features
+
+    @property
+    def parallel_requests(self) -> bool:
+        return bool(
+            self._settings.get(CONF_PARALLEL_REQUESTS, DEFAULT_PARALLEL_REQUESTS)
+        )
 
     def _wan_status_entity_selected(self, unique_id: str) -> bool:
         prefix = f"glinet_sensor/{self.device_mac}/"
@@ -239,12 +251,16 @@ class GLinetHub(DataUpdateCoordinator[None]):
                 "wireguard_client",
                 "vpn_client",
                 "wg_client",
+                "vpn_tunnel/wg",
+                "vpn_tunnel/unknown",
             ],
             FEATURE_WG_SERVER: [
                 "wg_server",
             ],
             FEATURE_OVPN_CLIENT: [
                 "ovpn_client",
+                "vpn_tunnel/ovpn",
+                "vpn_tunnel/unknown",
             ],
             FEATURE_OVPN_SERVER: [
                 "ovpn_server",
@@ -452,6 +468,19 @@ class GLinetHub(DataUpdateCoordinator[None]):
             self._ovpn_clients = {}
             self._ovpn_connections = None
 
+        # 4.9+ exposes a unified VPN dashboard. When either feature is
+        # enabled we fetch the dashboard tunnels so the entity layer can
+        # surface them as switches. The legacy per-profile state is still
+        # populated above for 4.8 backward compatibility.
+        if (
+            self.feature_enabled(FEATURE_WG_CLIENT)
+            or self.feature_enabled(FEATURE_OVPN_CLIENT)
+        ):
+            tasks.append(self.fetch_vpn_tunnels())
+        else:
+            self._vpn_tunnels = {}
+            self._vpn_tunnel_connections = None
+
         if self.feature_enabled(FEATURE_OVPN_SERVER):
             tasks.append(self.fetch_ovpn_server_status())
         else:
@@ -529,8 +558,29 @@ class GLinetHub(DataUpdateCoordinator[None]):
             self._black_mac = []
             self._white_mac = []
 
-        for task in tasks:
-            await task
+        # The user can opt into running fetches concurrently via the
+        # ``parallel_requests`` option in the config / options flow.
+        # Concurrent execution cuts total refresh time roughly to the
+        # slowest single fetch but puts more load on the router, so it
+        # defaults to off and is intended for capable hardware.
+        if self.parallel_requests:
+            # ``return_exceptions=True`` ensures a single failing fetch
+            # does not abort the rest of the coordinator refresh. The
+            # per-feature fetchers already swallow their own errors via
+            # ``_invoke_api`` / ``_invoke_optional_api`` and return
+            # ``None``/empty payloads on failure, so this is belt and
+            # braces.
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    _LOGGER.debug(
+                        "Parallel fetch raised: %s",
+                        result,
+                        exc_info=result,
+                    )
+        else:
+            for task in tasks:
+                await task
 
         if run_upgrade_check:
             self._last_upgrade_check = utcnow()
@@ -1035,6 +1085,129 @@ class GLinetHub(DataUpdateCoordinator[None]):
             lambda: self.router_api.wg_client.stop_wireguard_client(group_id, peer_id)
         )
         await self.fetch_wireguard_clients()
+
+    # ------------------------------------------------------------------
+    # 4.9+ VPN dashboard (unified tunnel management)
+    # ------------------------------------------------------------------
+
+    def _dashboard_vpn_client(self) -> Any | None:
+        api = getattr(self, "_api", None)
+        if api is None:
+            return None
+        wg_client = getattr(api, "wg_client", None)
+        if wg_client is None:
+            return None
+        return getattr(wg_client, "vpn_client", None)
+
+    async def _is_dashboard_supported(self) -> bool:
+        api = getattr(self, "_api", None)
+        if api is None or self._dashboard_vpn_client() is None:
+            return False
+        try:
+            return await api._is_firmware_at_least((4, 9, 0, 0))
+        except (APIClientError, OSError, ValueError):
+            return False
+
+    async def fetch_vpn_tunnels(self) -> None:
+        vpn_client = self._dashboard_vpn_client()
+        if not await self._is_dashboard_supported() or vpn_client is None:
+            # 4.8 / unsupported - clear any stale state from a previous run
+            self._vpn_tunnels = {}
+            self._vpn_tunnel_connections = []
+            return
+
+        tunnel_response = await self._invoke_optional_api(vpn_client.get_tunnel)
+        if not tunnel_response:
+            self._vpn_tunnels = {}
+            self._vpn_tunnel_connections = []
+            return
+
+        tunnels: dict[int, VpnTunnel] = {}
+        defaults = tunnel_response.get("default_tunnels") or []
+        user_tunnels = tunnel_response.get("tunnels") or []
+
+        for raw in defaults:
+            if not isinstance(raw, dict):
+                continue
+            try:
+                tunnel = VpnTunnel.from_api_response(raw, is_default=True)
+            except (TypeError, ValueError):
+                continue
+            if tunnel.tunnel_id:
+                tunnels[tunnel.tunnel_id] = tunnel
+
+        for raw in user_tunnels:
+            if not isinstance(raw, dict):
+                continue
+            try:
+                tunnel = VpnTunnel.from_api_response(raw, is_default=False)
+            except (TypeError, ValueError):
+                continue
+            if tunnel.tunnel_id:
+                tunnels[tunnel.tunnel_id] = tunnel
+
+        self._vpn_tunnels = tunnels
+
+        # Connection state from vpn-client.get_status
+        status_response = await self._invoke_optional_api(vpn_client.get_status)
+        active_ids: set[int] = set()
+        if isinstance(status_response, dict):
+            for item in status_response.get("status_list") or []:
+                if not isinstance(item, dict):
+                    continue
+                tid = item.get("tunnel_id")
+                if tid is None:
+                    continue
+                if int(item.get("status", 0)) == 1 or bool(item.get("enabled", False)):
+                    active_ids.add(int(tid))
+        elif isinstance(status_response, list):
+            for item in status_response:
+                if not isinstance(item, dict):
+                    continue
+                tid = item.get("tunnel_id")
+                if tid is None:
+                    continue
+                if int(item.get("status", 0)) == 1 or bool(item.get("enabled", False)):
+                    active_ids.add(int(tid))
+
+        connections: list[VpnTunnel] = []
+        for tunnel_id, tunnel in tunnels.items():
+            tunnel.connected = tunnel_id in active_ids
+            if tunnel.connected:
+                connections.append(tunnel)
+
+        self._vpn_tunnel_connections = connections
+
+        # Notify subscribers (e.g. the switch platform) so they can add new
+        # tunnel switches and remove ones that no longer exist on the router.
+        # The payload is the full set of tunnel ids so consumers can diff it
+        # against the entities they currently have registered.
+        try:
+            async_dispatcher_send(
+                self.hass, self.event_vpn_tunnels_updated, set(tunnels.keys())
+            )
+        except Exception:  # noqa: BLE001 - never fail the fetch on dispatcher errors
+            _LOGGER.debug(
+                "Failed to dispatch vpn tunnels updated event", exc_info=True
+            )
+
+    async def set_vpn_tunnel(self, tunnel_id: int, enabled: bool) -> None:
+        vpn_client = self._dashboard_vpn_client()
+        if vpn_client is None:
+            raise RuntimeError("VPN dashboard is not available on this firmware")
+        await self._invoke_api(
+            lambda: vpn_client.set_tunnel(
+                tunnel_id=int(tunnel_id),
+                enabled=bool(enabled),
+            )
+        )
+        # Refresh both the dashboard and the legacy per-profile state so
+        # consumers relying on either representation stay in sync.
+        await self.fetch_vpn_tunnels()
+        if self.feature_enabled(FEATURE_WG_CLIENT):
+            await self.fetch_wireguard_clients()
+        if self.feature_enabled(FEATURE_OVPN_CLIENT):
+            await self.fetch_ovpn_clients()
 
     async def fetch_wg_server_status(self) -> None:
         response = await self._invoke_api(self.router_api.wg_server.get_status)
@@ -1580,6 +1753,14 @@ class GLinetHub(DataUpdateCoordinator[None]):
         return self._wireguard_connections
 
     @property
+    def vpn_tunnels(self) -> dict[int, VpnTunnel]:
+        return self._vpn_tunnels
+
+    @property
+    def connected_vpn_tunnels(self) -> list[VpnTunnel] | None:
+        return self._vpn_tunnel_connections
+
+    @property
     def wg_server_status(self) -> WireGuardServerStatus | None:
         if not self._wg_server_status:
             return None
@@ -1614,6 +1795,8 @@ class GLinetHub(DataUpdateCoordinator[None]):
     @property
     def active_vpn_connections(self) -> list[Any]:
         connections = []
+        if self._vpn_tunnel_connections:
+            connections.extend(self._vpn_tunnel_connections)
         if self._wireguard_connections:
             connections.extend(self._wireguard_connections)
         if self._ovpn_connections:
@@ -1821,6 +2004,10 @@ class GLinetHub(DataUpdateCoordinator[None]):
     @property
     def event_networks_updated(self) -> str:
         return f"{DOMAIN}-networks-update-{self._factory_mac}"
+
+    @property
+    def event_vpn_tunnels_updated(self) -> str:
+        return f"{DOMAIN}-vpn-tunnels-updated-{self._factory_mac}"
 
 
 def _merge_modem_lists(

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -35,8 +35,10 @@ from .api import (
     TailscaleConnection,
     TokenError,
 )
+from .api.const import FIRMWARE_4_9
 from .api.exceptions import AuthenticationError
 from .api.models import RouterStatus
+from .api.utils import decode_firmware_version
 from .const import (
     API_PATH,
     CONF_ADD_ALL_DEVICES,
@@ -191,9 +193,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
     @property
     def parallel_requests(self) -> bool:
-        return bool(
-            self._settings.get(CONF_PARALLEL_REQUESTS, DEFAULT_PARALLEL_REQUESTS)
-        )
+        return bool(self._settings.get(CONF_PARALLEL_REQUESTS, DEFAULT_PARALLEL_REQUESTS))
 
     def _wan_status_entity_selected(self, unique_id: str) -> bool:
         prefix = f"glinet_sensor/{self.device_mac}/"
@@ -227,6 +227,13 @@ class GLinetHub(DataUpdateCoordinator[None]):
             suffix == interface or suffix == f"{interface}_{protocol}"
             for interface, protocol in selected_parts
         )
+
+    def _is_legacy_cellular_signal_sensor(self, unique_id: str) -> bool:
+        prefix = f"glinet_sensor/{self.device_mac}/"
+        if not unique_id.startswith(prefix):
+            return False
+        suffix = unique_id.removeprefix(prefix)
+        return suffix in {"cellular_signal", "cellular_rssi", "cellular_network"}
 
     async def async_initialize_hub(self) -> None:
         if not self._late_init_complete:
@@ -312,6 +319,18 @@ class GLinetHub(DataUpdateCoordinator[None]):
                 _LOGGER.debug(
                     "Removing unselected WAN status entity %s",
                     entry.entity_id,
+                )
+                entity_registry.async_remove(entry.entity_id)
+                removed = True
+
+            if (
+                not removed
+                and self.is_firmware_4_9_or_above
+                and self._is_legacy_cellular_signal_sensor(entry.unique_id)
+            ):
+                _LOGGER.debug(
+                    "Removing legacy cellular signal sensor %s (firmware 4.9+)",
+                    entry.unique_id,
                 )
                 entity_registry.async_remove(entry.entity_id)
                 removed = True
@@ -472,10 +491,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
         # enabled we fetch the dashboard tunnels so the entity layer can
         # surface them as switches. The legacy per-profile state is still
         # populated above for 4.8 backward compatibility.
-        if (
-            self.feature_enabled(FEATURE_WG_CLIENT)
-            or self.feature_enabled(FEATURE_OVPN_CLIENT)
-        ):
+        if self.feature_enabled(FEATURE_WG_CLIENT) or self.feature_enabled(FEATURE_OVPN_CLIENT):
             tasks.append(self.fetch_vpn_tunnels())
         else:
             self._vpn_tunnels = {}
@@ -1183,13 +1199,9 @@ class GLinetHub(DataUpdateCoordinator[None]):
         # The payload is the full set of tunnel ids so consumers can diff it
         # against the entities they currently have registered.
         try:
-            async_dispatcher_send(
-                self.hass, self.event_vpn_tunnels_updated, set(tunnels.keys())
-            )
+            async_dispatcher_send(self.hass, self.event_vpn_tunnels_updated, set(tunnels.keys()))
         except Exception:  # noqa: BLE001 - never fail the fetch on dispatcher errors
-            _LOGGER.debug(
-                "Failed to dispatch vpn tunnels updated event", exc_info=True
-            )
+            _LOGGER.debug("Failed to dispatch vpn tunnels updated event", exc_info=True)
 
     async def set_vpn_tunnel(self, tunnel_id: int, enabled: bool) -> None:
         vpn_client = self._dashboard_vpn_client()
@@ -1433,6 +1445,10 @@ class GLinetHub(DataUpdateCoordinator[None]):
             dict(status_response or {}).get("modems", []),
         )
         self._modems = {_modem_key(modem): modem for modem in modems if modem.get("bus")}
+
+        if self.is_firmware_4_9_or_above and self._modems:
+            await self._apply_49_sim_config_to_modems(self._modems)
+
         default_modem = _select_sms_modem(self._modems)
         self._default_modem_bus = str(default_modem.get("bus")) if default_modem else None
         self._default_modem_slot = default_modem.get("slot") if default_modem else None
@@ -1441,6 +1457,66 @@ class GLinetHub(DataUpdateCoordinator[None]):
             "default_bus": self._default_modem_bus,
             "default_slot": self._default_modem_slot,
         }
+
+    async def _apply_49_sim_config_to_modems(
+        self,
+        modems: dict[str, dict[str, Any]],
+    ) -> None:
+        if not modems:
+            return
+        seen_buses: set[str] = set()
+        for modem in modems.values():
+            bus = modem.get("bus")
+            if not bus or bus in seen_buses:
+                continue
+            seen_buses.add(bus)
+            sim_response = await self._invoke_optional_api(
+                lambda b=bus: self.router_api.modem.get_sim_config(b)
+            )
+            if not sim_response:
+                continue
+            self._merge_sim_config(modem, sim_response)
+
+    def _merge_sim_config(
+        self,
+        modem: dict[str, Any],
+        sim_response: dict[str, Any],
+    ) -> None:
+        if not isinstance(sim_response, dict):
+            return
+        modem_iccid = str(modem.get("iccid") or "")
+        chosen: dict[str, Any] | None = None
+        if modem_iccid and modem_iccid in sim_response:
+            chosen = sim_response[modem_iccid]
+        else:
+            for value in sim_response.values():
+                if isinstance(value, dict):
+                    chosen = value
+                    break
+        if not isinstance(chosen, dict):
+            return
+        apn = chosen.get("apn")
+        if not apn:
+            return
+        simcard = modem.get("simcard")
+        if not isinstance(simcard, dict):
+            simcard = {}
+        simcard["apn"] = apn
+        sim_fields = (
+            "iccid",
+            "username",
+            "password",
+            "pincode",
+            "auth",
+            "ip_type",
+            "roaming",
+            "cid",
+        )
+        for key in sim_fields:
+            value = chosen.get(key)
+            if value is not None and key not in simcard:
+                simcard[key] = value
+        modem["simcard"] = simcard
 
     async def fetch_repeater_status(self) -> None:
         response = await self._invoke_optional_api(self.router_api.repeater.get_status)
@@ -1617,28 +1693,15 @@ class GLinetHub(DataUpdateCoordinator[None]):
     async def remove_sms(self, scope: int, message_id: str | None = None) -> None:
         message = self._sms_messages.get(message_id) if message_id else None
         bus = message.bus if message else self._default_modem_bus
-        slot = (
-            getattr(message, "slot", None)
-            if message
-            else getattr(self, "_default_modem_slot", None)
-        )
 
         if bus is None:
             await self.fetch_cellular_status()
             bus = self._default_modem_bus
-            slot = self._default_modem_slot
         if bus is None:
             raise RuntimeError("No GL.iNet modem bus is available for SMS removal")
 
-        if slot is None:
-
-            async def api_call():
-                return await self.router_api.modem.remove_sms(bus, scope, message_id)
-
-        else:
-
-            async def api_call():
-                return await self.router_api.modem.remove_sms(bus, scope, message_id, slot=slot)
+        async def api_call():
+            return await self.router_api.modem.remove_sms(bus, scope, message_id)
 
         await self._invoke_optional_api(api_call)
         if scope == 10 and message_id:
@@ -1723,6 +1786,25 @@ class GLinetHub(DataUpdateCoordinator[None]):
     @property
     def firmware_version(self) -> str:
         return self._sw_version
+
+    @property
+    def firmware_version_tuple(self) -> tuple[int, int, int, int] | None:
+        version = (self._sw_version or "").strip()
+        if not version or version == "UNKNOWN":
+            return None
+        try:
+            return decode_firmware_version(version)
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def is_firmware_4_9_or_above(self) -> bool:
+        version_tuple = self.firmware_version_tuple
+        if version_tuple is not None:
+            return version_tuple >= FIRMWARE_4_9
+        api = getattr(self, "_api", None)
+        cached = getattr(api, "_firmware_version", None) if api is not None else None
+        return cached is not None and cached >= FIRMWARE_4_9
 
     @property
     def upgrade_info(self) -> dict[str, Any]:

--- a/custom_components/glinet_router/manifest.json
+++ b/custom_components/glinet_router/manifest.json
@@ -15,10 +15,10 @@
       "macaddress": "9483C4*"
     }
   ],
-  "documentation": "https://github.com/vithurshanselvarajah/glinet-router",
+  "documentation": "https://github.com/vithurshanselvarajah/ha-glinet-router",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/vithurshanselvarajah/glinet-router/issues",
+  "issue_tracker": "https://github.com/vithurshanselvarajah/ha-glinet-router/issues",
   "requirements": [
     "passlib==1.7.4"
   ],

--- a/custom_components/glinet_router/manifest.json
+++ b/custom_components/glinet_router/manifest.json
@@ -22,5 +22,5 @@
   "requirements": [
     "passlib==1.7.4"
   ],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/custom_components/glinet_router/models.py
+++ b/custom_components/glinet_router/models.py
@@ -156,7 +156,7 @@ class WireGuardServerStatus:
             rx_bytes=server.get("rx_bytes", 0),
             tx_bytes=server.get("tx_bytes", 0),
         )
-    
+
 
 @dataclass(slots=True)
 class OpenVpnClient:
@@ -255,10 +255,7 @@ class ParentalGroup:
         group_id = str(data.get("id") or data.get("group_id") or data.get(".name") or "")
         name = str(data.get("name") or data.get("alias") or group_id)
         macs = _mac_list(
-            data.get("mac")
-            or data.get("macs")
-            or data.get("clients")
-            or data.get("devices")
+            data.get("mac") or data.get("macs") or data.get("clients") or data.get("devices")
         )
         rule = data.get("rule") or data.get("rule_id")
         return cls(
@@ -278,11 +275,7 @@ class ParentalGroup:
             ),
             active_schedule_ids=[
                 str(item)
-                for item in (
-                    data.get("active_schedule_ids")
-                    or data.get("active_schedules")
-                    or []
-                )
+                for item in (data.get("active_schedule_ids") or data.get("active_schedules") or [])
             ],
             raw=dict(data),
         )
@@ -465,7 +458,7 @@ class ClientDeviceInfo:
 
         if self._connected:
             self._connected = (now - self._last_activity).total_seconds() < consider_home
-        
+
         if not self._connected:
             self._ip_address = None
 

--- a/custom_components/glinet_router/models.py
+++ b/custom_components/glinet_router/models.py
@@ -132,6 +132,74 @@ class WireGuardClient:
     tunnel_id: int | None = None
 
 
+class VpnTunnelType(StrEnum):
+    WIREGUARD = "wireguard"
+    OPENVPN = "openvpn"
+    UNKNOWN = "unknown"
+
+
+@dataclass(slots=True)
+class VpnTunnel:
+
+    tunnel_id: int
+    name: str
+    tunnel_type: VpnTunnelType
+    enabled: bool = False
+    connected: bool = field(compare=False, default=False)
+    killswitch: bool = False
+    group_id: int | None = None
+    peer_id: int | None = None
+    client_id: int | None = None
+    via: str | None = None
+    is_default: bool = False
+
+    @classmethod
+    def from_api_response(cls, data: dict, *, is_default: bool = False) -> VpnTunnel:
+        via = data.get("via") or {}
+        raw_type = via.get("type") or data.get("type")
+        try:
+            tunnel_type = VpnTunnelType(raw_type) if raw_type else VpnTunnelType.UNKNOWN
+        except ValueError:
+            tunnel_type = VpnTunnelType.UNKNOWN
+
+        configs = via.get("configs") if isinstance(via, dict) else None
+        group_id: int | None = None
+        peer_id: int | None = None
+        client_id: int | None = None
+        if isinstance(configs, list) and configs:
+            first = configs[0] if isinstance(configs[0], dict) else {}
+            group_id = first.get("group_id")
+            id_list = first.get("id_list")
+            if isinstance(id_list, list) and id_list:
+                raw_inner = id_list[0]
+                if tunnel_type == VpnTunnelType.WIREGUARD:
+                    peer_id = int(raw_inner) if raw_inner is not None else None
+                elif tunnel_type == VpnTunnelType.OPENVPN:
+                    client_id = int(raw_inner) if raw_inner is not None else None
+        # Fallback keys in case via is shaped differently
+        if group_id is None and isinstance(via, dict):
+            group_id = via.get("group_id")
+        if peer_id is None and isinstance(via, dict) and tunnel_type == VpnTunnelType.WIREGUARD:
+            peer_id = via.get("peer_id")
+        if client_id is None and isinstance(via, dict) and tunnel_type == VpnTunnelType.OPENVPN:
+            client_id = via.get("client_id")
+
+        tunnel_id = data.get("tunnel_id")
+        return cls(
+            tunnel_id=int(tunnel_id) if tunnel_id is not None else 0,
+            name=str(data.get("name") or f"Tunnel {tunnel_id or ''}").strip()
+            or f"Tunnel {tunnel_id or ''}",
+            tunnel_type=tunnel_type,
+            enabled=bool(data.get("enabled", False)),
+            killswitch=bool(data.get("killswitch", False)),
+            group_id=int(group_id) if group_id is not None else None,
+            peer_id=int(peer_id) if peer_id is not None else None,
+            client_id=int(client_id) if client_id is not None else None,
+            via=str(via.get("via")) if isinstance(via, dict) and via.get("via") else None,
+            is_default=is_default,
+        )
+
+
 @dataclass(slots=True)
 class WireGuardServerStatus:
     enabled: bool

--- a/custom_components/glinet_router/models.py
+++ b/custom_components/glinet_router/models.py
@@ -140,7 +140,6 @@ class VpnTunnelType(StrEnum):
 
 @dataclass(slots=True)
 class VpnTunnel:
-
     tunnel_id: int
     name: str
     tunnel_type: VpnTunnelType

--- a/custom_components/glinet_router/services.py
+++ b/custom_components/glinet_router/services.py
@@ -94,6 +94,7 @@ from .const import (
     SERVICE_PARENTAL_CONTROL_SET_TEMPORARY_OVERRIDE,
     SERVICE_PARENTAL_CONTROL_UPDATE_SIGNATURES,
     SERVICE_PLAYGROUND,
+    SERVICE_REFRESH_CLIENTS,
     SERVICE_REFRESH_SMS,
     SERVICE_REMOVE_FIREWALL_RULE,
     SERVICE_REMOVE_PORT_FORWARD,
@@ -139,12 +140,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
     firewall_enabled = any(
         FEATURE_FIREWALL in _enabled_features_from_entry(entry) for entry in entries
     )
-    mwan3_enabled = any(
-        FEATURE_MWAN3 in _enabled_features_from_entry(entry) for entry in entries
-    )
-    kmwan_enabled = any(
-        FEATURE_KMWAN in _enabled_features_from_entry(entry) for entry in entries
-    )
+    mwan3_enabled = any(FEATURE_MWAN3 in _enabled_features_from_entry(entry) for entry in entries)
+    kmwan_enabled = any(FEATURE_KMWAN in _enabled_features_from_entry(entry) for entry in entries)
     mcu_battery_enabled = any(
         FEATURE_MCU_BATTERY in _enabled_features_from_entry(entry) for entry in entries
     )
@@ -156,8 +153,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
         FEATURE_REPEATER in _enabled_features_from_entry(entry) for entry in entries
     )
     parental_control_enabled = any(
-        FEATURE_PARENTAL_CONTROL in _enabled_features_from_entry(entry)
-        for entry in entries
+        FEATURE_PARENTAL_CONTROL in _enabled_features_from_entry(entry) for entry in entries
     )
     playground_enabled = any(
         FEATURE_PLAYGROUND in _enabled_features_from_entry(entry) for entry in entries
@@ -166,6 +162,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
     async def async_set_fan_temperature(call: ServiceCall) -> None:
         hub = _get_hub(hass, call.data)
         await hub.set_fan_temperature(call.data[ATTR_TEMPERATURE])
+
+    async def async_refresh_clients(call: ServiceCall) -> None:
+        hub = _get_hub(hass, call.data)
+        await hub.fetch_connected_devices()
+        await hub.async_request_refresh()
 
     async def async_mwan3_get_config(call: ServiceCall) -> ServiceResponse:
         hub = _get_hub(hass, call.data)
@@ -945,11 +946,16 @@ async def async_register_services(hass: HomeAssistant) -> None:
         schema=vol.Schema(
             {
                 vol.Optional(CONF_MAC): cv.string,
-                vol.Required(ATTR_TEMPERATURE): vol.All(
-                    vol.Coerce(int), vol.Range(min=70, max=90)
-                ),
+                vol.Required(ATTR_TEMPERATURE): vol.All(vol.Coerce(int), vol.Range(min=70, max=90)),
             }
         ),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_CLIENTS,
+        async_refresh_clients,
+        schema=vol.Schema({vol.Optional(CONF_MAC): cv.string}),
     )
 
 

--- a/custom_components/glinet_router/translations/en.json
+++ b/custom_components/glinet_router/translations/en.json
@@ -15,7 +15,8 @@
           "cleanup_devices": "Auto-cleanup unknown devices",
           "unknown_devices_filter_mode": "Unknown Devices Filter Mode",
           "unknown_devices_filter_select": "Select Unknown Devices",
-          "unknown_devices_filter_manual": "Unknown Devices Manual MAC Address List (One per line)"
+          "unknown_devices_filter_manual": "Unknown Devices Manual MAC Address List (One per line)",
+          "parallel_requests": "Faster updates (parallel fetching)"
         },
         "data_description": {
           "host": "Type the router hostname, URL, or IP address.",
@@ -28,7 +29,8 @@
           "cleanup_devices": "Set this to 0 to disable automatic cleanup. Any other number is treated as minutes; unknown discovered devices are removed after that period if they remain offline or disconnected.",
           "unknown_devices_filter_mode": "Select whether the list of unknown devices behaves as a whitelist or blacklist. (Blank defaults to Blacklist which won't block anything)",
           "unknown_devices_filter_select": "Select from currently discovered unknown devices to whitelist or blacklist.",
-          "unknown_devices_filter_manual": "Manually enter MAC addresses (one per line) of unknown devices to whitelist or blacklist."
+          "unknown_devices_filter_manual": "Manually enter MAC addresses (one per line) of unknown devices to whitelist or blacklist.",
+          "parallel_requests": "Fetch data from all features at the same time to speed up each refresh. Off (default) is gentler on small routers."
         }
       }
     },
@@ -55,7 +57,8 @@
           "cleanup_devices": "Auto-cleanup unknown devices",
           "unknown_devices_filter_mode": "Unknown Devices Filter Mode",
           "unknown_devices_filter_select": "Select Unknown Devices",
-          "unknown_devices_filter_manual": "Unknown Devices Manual MAC Address List (One per line)"
+          "unknown_devices_filter_manual": "Unknown Devices Manual MAC Address List (One per line)",
+          "parallel_requests": "Faster updates (parallel fetching)"
         },
         "data_description": {
           "host": "Type the router hostname, URL, or IP address.",
@@ -68,7 +71,8 @@
           "cleanup_devices": "Set this to 0 to disable automatic cleanup. Any other number is treated as minutes; unknown discovered devices are removed after that period if they remain offline or disconnected.",
           "unknown_devices_filter_mode": "Select whether the list of unknown devices behaves as a whitelist or blacklist. (Blank defaults to Blacklist which won't block anything)",
           "unknown_devices_filter_select": "Select from currently discovered unknown devices to whitelist or blacklist.",
-          "unknown_devices_filter_manual": "Manually enter MAC addresses (one per line) of unknown devices to whitelist or blacklist."
+          "unknown_devices_filter_manual": "Manually enter MAC addresses (one per line) of unknown devices to whitelist or blacklist.",
+          "parallel_requests": "Fetch data from all features at the same time to speed up each refresh. Off (default) is gentler on small routers."
         }
       }
     }

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -6,40 +6,40 @@ Welcome to the `glinet-router` documentation. This wiki is meant to help you fin
 
 These pages cover what the integration provides, how to configure it, and how to use it in Home Assistant.
 
-- [Feature Matrix](https://github.com/vithurshanselvarajah/glinet-router/wiki/features) - A quick overview of supported features and actions.
-- [Entity Reference](https://github.com/vithurshanselvarajah/glinet-router/wiki/entities) - Detailed list of sensors, switches, buttons, and trackers.
-- [Services & Actions](https://github.com/vithurshanselvarajah/glinet-router/wiki/services) - Guide on using Home Assistant services to control your router.
-- [Automation Templates](https://github.com/vithurshanselvarajah/glinet-router/wiki/automations) - Ready-made automations you can paste into Home Assistant.
-- [Smart Fan Controls](https://github.com/vithurshanselvarajah/glinet-router/wiki/smart-fan) - Fan status, speed, and temperature threshold controls.
-- [Unknown Device Management](https://github.com/vithurshanselvarajah/glinet-router/wiki/unknown-devices) - Discovery, cleanup, and allow/blocklist handling for unknown devices.
+- [Feature Matrix](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/features) - A quick overview of supported features and actions.
+- [Entity Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/entities) - Detailed list of sensors, switches, buttons, and trackers.
+- [Services & Actions](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/services) - Guide on using Home Assistant services to control your router.
+- [Automation Templates](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/automations) - Ready-made automations you can paste into Home Assistant.
+- [Smart Fan Controls](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) - Fan status, speed, and temperature threshold controls.
+- [Unknown Device Management](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/unknown-devices) - Discovery, cleanup, and allow/blocklist handling for unknown devices.
 
 ### Optional Features
 
 These pages cover configuration, entities, and services for optional modules that can be enabled on supported routers:
 
-- [Cellular](https://github.com/vithurshanselvarajah/glinet-router/wiki/cellular) - Monitor cellular connection, signals, and modem diagnostics.
-- [Repeater](https://github.com/vithurshanselvarajah/glinet-router/wiki/repeater) - Connect to and scan for external WiFi networks, manage saved networks.
-- [SMS](https://github.com/vithurshanselvarajah/glinet-router/wiki/sms) - Send, receive, and delete text messages.
-- [Tailscale](https://github.com/vithurshanselvarajah/glinet-router/wiki/tailscale) - Enable or disable Tailscale integration.
-- [WireGuard Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-client) - Toggle configured WireGuard client profiles.
-- [WireGuard Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-server) - Manage the built-in WireGuard server.
-- [OpenVPN Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-client) - Manage and select OpenVPN client configurations.
-- [OpenVPN Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-server) - Manage the built-in OpenVPN server.
-- [ZeroTier](https://github.com/vithurshanselvarajah/glinet-router/wiki/zerotier) - Enable or disable ZeroTier VPN connections.
-- [AdGuard Home](https://github.com/vithurshanselvarajah/glinet-router/wiki/adguard-home) - Enable/disable AdGuard Home and DNS redirection.
-- [Firewall](https://github.com/vithurshanselvarajah/glinet-router/wiki/firewall) - Manage firewall rules, port forwarding, and DMZ settings.
-- [MCU Battery](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-battery) - Monitor battery status and configure high/low temperature warnings.
-- [MCU OLED](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-oled) - Configure what is displayed on the router's OLED screen.
-- [Parental & Access Control](https://github.com/vithurshanselvarajah/glinet-router/wiki/parental-control) - Manage internet access blocks and parental group rules per client.
-- [API Playground](https://github.com/vithurshanselvarajah/glinet-router/wiki/playground) - Send custom JSON-RPC or ubus commands and inspect the response.
+- [Cellular](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/cellular) - Monitor cellular connection, signals, and modem diagnostics.
+- [Repeater](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/repeater) - Connect to and scan for external WiFi networks, manage saved networks.
+- [SMS](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/sms) - Send, receive, and delete text messages.
+- [Tailscale](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/tailscale) - Enable or disable Tailscale integration.
+- [WireGuard Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-client) - Toggle configured WireGuard client profiles.
+- [WireGuard Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-server) - Manage the built-in WireGuard server.
+- [OpenVPN Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-client) - Manage and select OpenVPN client configurations.
+- [OpenVPN Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-server) - Manage the built-in OpenVPN server.
+- [ZeroTier](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/zerotier) - Enable or disable ZeroTier VPN connections.
+- [AdGuard Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/adguard-home) - Enable/disable AdGuard Home and DNS redirection.
+- [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) - Manage firewall rules, port forwarding, and DMZ settings.
+- [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) - Monitor battery status and configure high/low temperature warnings.
+- [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) - Configure what is displayed on the router's OLED screen.
+- [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) - Manage internet access blocks and parental group rules per client.
+- [API Playground](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground) - Send custom JSON-RPC or ubus commands and inspect the response.
 
 ## For Developers
 
 These pages are aimed at the architecture, API details, and maintenance work behind the integration.
 
-- [Developer Reference](https://github.com/vithurshanselvarajah/glinet-router/wiki/developer-reference) - Start here for contribution notes, tooling, and project structure.
-- [Architecture](https://github.com/vithurshanselvarajah/glinet-router/wiki/architecture) - How the integration is structured and interacts with Home Assistant.
-- [Runtime State & Poller (Hub)](https://github.com/vithurshanselvarajah/glinet-router/wiki/hub) - Details on the `GLinetHub` and `DataUpdateCoordinator`.
-- [Router API Notes](https://github.com/vithurshanselvarajah/glinet-router/wiki/router-api) - Notes on the GL.iNet JSON-RPC API and authentication.
-- [Modem API Coverage](https://github.com/vithurshanselvarajah/glinet-router/wiki/modem-api) - Details on the optional cellular modem API.
-- [CI and Release Workflows](https://github.com/vithurshanselvarajah/glinet-router/wiki/ci-release) - How automated testing and releases work.
+- [Developer Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/developer-reference) - Start here for contribution notes, tooling, and project structure.
+- [Architecture](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/architecture) - How the integration is structured and interacts with Home Assistant.
+- [Runtime State & Poller (Hub)](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub) - Details on the `GLinetHub` and `DataUpdateCoordinator`.
+- [Router API Notes](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) - Notes on the GL.iNet JSON-RPC API and authentication.
+- [Modem API Coverage](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/modem-api) - Details on the optional cellular modem API.
+- [CI and Release Workflows](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/ci-release) - How automated testing and releases work.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -2,6 +2,79 @@
 
 Welcome to the `glinet-router` documentation. This wiki is meant to help you find the right guide quickly, whether you are setting up the integration for the first time or looking for a specific feature.
 
+## About this Integration
+
+`glinet-router` is a **local polling** Home Assistant integration for **GL.iNet** travel and home routers (such as the Beryl, Slate, Mango, Flint, and similar product lines). It talks directly to the router's built-in JSON-RPC endpoint (`/rpc`) over your local network — no cloud account, no third-party service, and no outbound traffic is required.
+
+The integration provides:
+
+- **Core router telemetry** — system load, memory/flash usage, CPU temperature, uptime, and WAN status for every detected interface.
+- **Device tracking & diagnostics** — connected clients with per-client bandwidth and IP address sensors.
+- **WiFi and hardware controls** — enable/disable individual SSIDs, toggle the system LED, run a fan test, or reboot the router.
+- **Optional modules** — cellular/modem status, repeater site surveys and saved networks, SMS send/receive, WireGuard & OpenVPN client/server toggles, Tailscale, ZeroTier, AdGuard Home, firewall rules & port forwards, KMWAN/MWAN3 multi-WAN policy, parental and access control, MCU battery & OLED configuration, and an API playground.
+- **Firmware updates** — a native Home Assistant update entity that pulls release notes from the router.
+- **Sanitized diagnostics** — diagnostic downloads with all sensitive data (passwords, tokens, MACs, phone numbers) masked.
+
+All communication happens over your local network using the credentials you provide during setup. If a feature isn't available on your router model, the integration detects that automatically and skips the related calls without breaking the rest of the integration.
+
+---
+
+## Installation
+
+### HACS (Recommended)
+
+1. Open HACS in Home Assistant.
+2. Search for **GL.iNet Router**.
+3. Click **Download**, then restart Home Assistant when the install finishes.
+
+### Manual
+
+1. Download the latest source code or release ZIP from the repository.
+2. Extract the `custom_components/glinet_router` directory.
+3. Copy the `glinet_router` folder into Home Assistant's `config/custom_components/` directory.
+4. Restart Home Assistant.
+
+### Prerequisites
+
+- A GL.iNet router running a firmware that exposes the local JSON-RPC API at `/rpc` (most recent GL.iNet 3.x and 4.x firmwares).
+- The admin password for the router's `root` account (this is the same password used to log in to the GL.iNet admin web UI).
+- Network reachability from the Home Assistant host to the router (default address `http://192.168.8.1`).
+
+### Setup
+
+1. In Home Assistant, go to **Settings → Devices & Services**.
+2. Click **Add Integration** in the bottom-right corner.
+3. Search for **GL.iNet** and select it.
+4. Enter your router URL (default: `http://192.168.8.1`) and admin password.
+5. Choose your setup options, including whether you want device tracking, the polling update frequency, and any optional features to enable.
+6. The integration will test the connection and authenticate before saving the entry.
+
+> The router is auto-discovered via DHCP if its hostname starts with `gl-` and the MAC prefix matches a known GL.iNet OUI (`94:83:C4:*`). In that case, Home Assistant will offer the integration in the **Discovered** section of **Devices & Services**.
+
+---
+
+## Removal
+
+To completely remove the GL.iNet Router integration from Home Assistant:
+
+1. Go to **Settings → Devices & Services**.
+2. Find the **GL.iNet Router** integration card and click it.
+3. Click the three-dot menu in the top-right corner of the device page and choose **Delete**.
+4. Confirm the deletion in the dialog.
+
+When removed, Home Assistant will:
+
+- Unload all platforms (sensors, switches, buttons, device trackers, select, update, binary sensor) created by the integration.
+- Remove the integration's config entry from `.storage/core.config_entries`.
+- Remove the device and its entities from the entity and device registries.
+- Forget the device's MAC address as a unique ID so you can re-add the same router later.
+
+> Removing the integration does **not** change any settings on the router itself — the router will continue running with whatever configuration you have on it. The integration only stops talking to the local JSON-RPC API.
+
+If you installed via HACS, you can additionally remove the custom repository from HACS to keep your store clean. If you installed manually, delete the `custom_components/glinet_router` directory and restart Home Assistant.
+
+---
+
 ## For End Users
 
 These pages cover what the integration provides, how to configure it, and how to use it in Home Assistant.
@@ -10,8 +83,21 @@ These pages cover what the integration provides, how to configure it, and how to
 - [Entity Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/entities) - Detailed list of sensors, switches, buttons, and trackers.
 - [Services & Actions](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/services) - Guide on using Home Assistant services to control your router.
 - [Automation Templates](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/automations) - Ready-made automations you can paste into Home Assistant.
-- [Smart Fan Controls](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) - Fan status, speed, and temperature threshold controls.
+- [Smart Fan](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) - Fan status, speed, and temperature threshold controls.
 - [Unknown Device Management](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/unknown-devices) - Discovery, cleanup, and allow/blocklist handling for unknown devices.
+- [Refresh Clients](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/refresh-clients) - Force a client list refresh outside the normal polling cycle.
+- [Targeting a Specific Router](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-targeting) - Use the optional `mac` parameter to address a single router.
+- [Triggers](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/triggers) - Building automations that react to GL.iNet router state.
+- [Conditions](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/conditions) - Using Home Assistant's built-in conditions on integration entities.
+
+### Core Entity Pages
+
+- [Buttons](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/buttons) - Reboot and fan test buttons.
+- [Firmware Update](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/update-entity) - Native Home Assistant firmware update entity.
+- [Device Trackers](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/device-trackers) - Per-client device tracking.
+- [System Sensors](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/system-sensors) - CPU, load, memory, flash, WAN status, and client bandwidth sensors.
+- [Core Switches](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/core-switches) - WiFi interface and system LED switches.
+- [Core Binary Sensors](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/core-binary-sensors) - Fan status and other core binary sensors.
 
 ### Optional Features
 
@@ -28,9 +114,17 @@ These pages cover configuration, entities, and services for optional modules tha
 - [ZeroTier](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/zerotier) - Enable or disable ZeroTier VPN connections.
 - [AdGuard Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/adguard-home) - Enable/disable AdGuard Home and DNS redirection.
 - [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) - Manage firewall rules, port forwarding, and DMZ settings.
+  - [Firewall Rules](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall-rules) - Add and remove custom firewall rules.
+  - [Port Forwards](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/port-forwards) - Add and remove port forwarding rules.
+  - [DMZ](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/dmz) - Toggle the DMZ and configure the target IP.
+  - [WAN Access](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wan-access) - Toggle WAN ping, HTTPS, and SSH remote access.
 - [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) - Monitor battery status and configure high/low temperature warnings.
 - [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) - Configure what is displayed on the router's OLED screen.
 - [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) - Manage internet access blocks and parental group rules per client.
+  - [Parental Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control-feature) - Group switches, filtering mode, overrides, and signature updates.
+  - [Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/access-control) - Per-client internet access switches and blacklist/whitelist controls.
+- [KMWAN](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/kmwan) - Read and update GL.iNet's KMWAN multi-WAN configuration.
+- [MWAN3](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mwan3) - Read and update MWAN3 multi-WAN configuration.
 - [API Playground](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground) - Send custom JSON-RPC or ubus commands and inspect the response.
 
 ## For Developers
@@ -40,6 +134,11 @@ These pages are aimed at the architecture, API details, and maintenance work beh
 - [Developer Reference](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/developer-reference) - Start here for contribution notes, tooling, and project structure.
 - [Architecture](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/architecture) - How the integration is structured and interacts with Home Assistant.
 - [Runtime State & Poller (Hub)](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub) - Details on the `GLinetHub` and `DataUpdateCoordinator`.
+  - [Hub Core Functions](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub-core) - Coordinator lifecycle and API helpers.
+  - [Data Fetching](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub-data-fetching) - Per-feature polling methods.
+  - [Action Functions](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub-action-functions) - Hub write methods.
+  - [Option Updates](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub-option-updates) - Runtime application of configuration option changes.
+  - [Parental Control Helpers](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/hub-parental-helpers) - Group lookup and access control helpers.
 - [Router API Notes](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) - Notes on the GL.iNet JSON-RPC API and authentication.
 - [Modem API Coverage](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/modem-api) - Details on the optional cellular modem API.
 - [CI and Release Workflows](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/ci-release) - How automated testing and releases work.

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,0 +1,43 @@
+# Access Control (Optional Feature)
+
+The **Access Control** feature lets you block or unblock individual client devices on your network, switch the access control mode between a blacklist and a whitelist, and view per-client internet access state.
+
+## Setup Configuration
+
+To enable this feature, check the **Parental & Access Control** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `parental_control`
+
+## Switches
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **Internet access** | One switch per tracked client device. Turning it off blocks that client's internet access; turning it on restores it. | `black_white_list/set_single_mac` |
+
+## Actions (Services)
+
+The following services are registered under the `glinet_router` domain when the Parental & Access Control feature is enabled:
+
+### `access_control_set_mode`
+
+Switches device access control between blacklist and whitelist modes.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mode` | string | Yes | `black` (blacklist) or `white` (whitelist). |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `access_control_set_device_block`
+
+Blocks or unblocks a specific client device by MAC address.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `src_mac` | string | Yes | Client MAC address. |
+| `block` | boolean | Yes | Whether internet access should be blocked. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Parental Control](parental-control.md) — Group switches, filtering mode, overrides, and signature updates.
+- [Parental & Access Control parent page](parental-control.md)

--- a/docs/adguard-home.md
+++ b/docs/adguard-home.md
@@ -18,3 +18,8 @@ To enable this feature, check the **AdGuard Home** option under **Enabled Featur
 | --- | --- | --- |
 | **AdGuard Home** | Toggles the AdGuard Home service on or off. | `adguardhome/get_config` / `adguardhome/set_config` |
 | **AdGuard Home DNS** | Toggles DNS redirection through AdGuard Home. | `adguardhome/get_config` / `adguardhome/set_config` |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,30 @@
 
 ## Polling
 
-The integration uses a user-configurable polling interval (defaulting to 30 seconds) managed by a `DataUpdateCoordinator`. This ensures efficient data fetching and automatic entity updates across all platforms without flooding the router.
+The integration uses a user-configurable polling interval (defaulting to 30 seconds, clamped to the 10–300s range by the config flow) managed by a `DataUpdateCoordinator`. This ensures efficient data fetching and automatic entity updates across all platforms without flooding the router.
 
 Optional modules (Cellular, SMS, VPNs, WAN policy, AdGuard Home) are handled defensively. If a router does not support an optional API (e.g., no modem present) or if it is disabled in the options flow, the coordinator logs a debug message and skips that data point, ensuring the core integration remains functional.
+
+## Config Flow & Setup
+
+- The config flow (`config_flow.py`) is the only supported setup path — `config_flow: true` is set in `manifest.json`.
+- During the user step, the flow calls `process_user_input` which:
+  1. Sends a reachability check (`is_router_reachable`) to the router.
+  2. Performs a full login (`authenticate` + `system.get_info`) to validate the password.
+  3. Discovers available WAN interfaces and rebuilds the WAN monitor selector.
+- On success, the unique ID is set to the lowercase, colon-separated MAC address via `format_mac` and the entry is rejected with `already_configured` if that MAC is already present. This guarantees a single config entry per physical router.
+- DHCP discovery (`async_step_dhcp`) is configured for hostnames starting with `gl-*` and the GL.iNet OUI `94:83:C4*`. Discovery pre-fills the host field and reuses the validation path with `raise_on_invalid_auth=False` so the user is not blocked by a temporary bad password during discovery.
+
+## Runtime Data
+
+Per the `runtime-data` quality scale rule, the hub instance is stored on `ConfigEntry.runtime_data` (not on `hass.data[DOMAIN]`). All entity platforms read it through `entry.runtime_data`, and platform/entity cleanup uses the standard Home Assistant lifecycle (`async_on_unload`, `entry.async_on_unload`).
+
+## Service Registration
+
+Services are registered in `async_setup_entry` (via `services.async_register_services`) rather than during `async_setup`, so each config entry drives the service registration that owns its router. Services are dynamically added or removed as features are enabled/disabled at the option-flow level, and removal is performed on entry unload.
+
+## Related Pages
+
+- [Developer Reference](developer-reference.md) — Contributing, tooling, and project structure.
+- [Runtime State & Poller (Hub)](hub.md) — Details on the `GLinetHub` and `DataUpdateCoordinator`.
+- [Router API Notes](router-api.md) — Endpoints, authentication, and module inventory.

--- a/docs/automation-sms-notification.md
+++ b/docs/automation-sms-notification.md
@@ -56,3 +56,8 @@ actions:
           enabled: true
 mode: single
 ```
+
+## Related Pages
+
+- [Automation Templates](automations.md) — Index of available automation templates.
+- [SMS](sms.md) — SMS feature reference.

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -21,3 +21,9 @@ Ready-made Home Assistant automation templates for the GL.iNet integration. Thes
 | Template | Description |
 |----------|-------------|
 | [SMS Notification](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/automation-sms-notification) | Forward incoming SMS from your router to Home Assistant persistent notifications. |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Triggers](triggers.md) — Building automations that react to GL.iNet router state.
+- [Conditions](conditions.md) — Using Home Assistant's built-in conditions on integration entities.

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -20,4 +20,4 @@ Ready-made Home Assistant automation templates for the GL.iNet integration. Thes
 
 | Template | Description |
 |----------|-------------|
-| [SMS Notification](https://github.com/vithurshanselvarajah/glinet-router/wiki/automation-sms-notification) | Forward incoming SMS from your router to Home Assistant persistent notifications. |
+| [SMS Notification](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/automation-sms-notification) | Forward incoming SMS from your router to Home Assistant persistent notifications. |

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -1,0 +1,14 @@
+# Buttons
+
+The integration exposes two core buttons that are always available regardless of optional feature selection.
+
+| Entity | Source | Notes |
+| --- | --- | --- |
+| **Reboot** | `system/reboot` | Reboots the router immediately. |
+| **Fan test** | `fan/set_test` | Diagnostic button to run the fan at full speed for 10 seconds. Available on routers with an active fan. |
+
+## Related Pages
+
+- [Entity Reference parent page](entities.md)
+- [Update](update-entity.md) — Firmware update entity.
+- [Device Trackers](device-trackers.md) — Per-client device tracking.

--- a/docs/cellular.md
+++ b/docs/cellular.md
@@ -34,4 +34,4 @@ To enable this feature, check the **Cellular** option under **Enabled Features**
 
 ## Developer Reference
 
-For details on how the modem APIs are queried and parsed, see the [Modem API Coverage](https://github.com/vithurshanselvarajah/glinet-router/wiki/modem-api) documentation.
+For details on how the modem APIs are queried and parsed, see the [Modem API Coverage](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/modem-api) documentation.

--- a/docs/cellular.md
+++ b/docs/cellular.md
@@ -35,3 +35,9 @@ To enable this feature, check the **Cellular** option under **Enabled Features**
 ## Developer Reference
 
 For details on how the modem APIs are queried and parsed, see the [Modem API Coverage](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/modem-api) documentation.
+
+## Related Pages
+
+- [Modem API Coverage](modem-api.md) — Details on how the modem APIs are queried and parsed.
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/cellular.md
+++ b/docs/cellular.md
@@ -7,9 +7,31 @@ The **Cellular** feature enables signal and network monitoring for GL.iNet route
 To enable this feature, check the **Cellular** option under **Enabled Features** in the integration configuration or options flow.
 
 - **Option key**: `cellular`
-- **Firmware support**: Firmware 4.8.x uses the aggregate modem API. Firmware 4.9+
-  uses the newer per-slot modem API and is normalized to the same Home Assistant
-  sensor attributes.
+- **Firmware support**:
+  - **Firmware 4.8.x** uses the aggregate modem API (`modem/get_status` and
+    `modem/get_info`). The APN, signal metrics, and the cellular WAN IP
+    all come from that single response.
+  - **Firmware 4.9+** uses the newer per-slot modem API. Several changes:
+    - The 4.9 firmware dropped the legacy **overall signal strength**
+      and **RSSI** readings — the corresponding Home Assistant sensors
+      (`Cellular signal`, `Cellular RSSI`) are no longer registered, and
+      the **Cellular network** sensor (which duplicated `Cellular band`)
+      is removed entirely. Existing installs have these entities
+      cleaned up automatically on the next reload.
+    - The cellular WAN IP is sourced from the bodyless
+      `modem/get_network_info` call, which returns the IPv4/IPv6 lease
+      per active SIM slot under `networks[].ipv4` / `networks[].ipv6`.
+    - The APN is no longer carried on the modem status payload. The
+      integration now issues a per-bus `modem/get_sim_config` call
+      (keyed by ICCID) and merges the APN onto each modem's `simcard`
+      so the `Cellular APN` sensor keeps working unchanged.
+    - The `kmwan/get_status` response keeps `modem_0001` as a logical
+      aggregate that the firmware always reports as Down
+      (`status_v4: 1`). The real link state is published under the
+      per-slot interfaces `modem_0001_s1` / `modem_0001_s2`. The
+      integration transparently resolves the cellular `WanStatusSensor`
+      to the active per-slot interface on 4.9+ so the `Cellular status`
+      sensor shows Up when the cellular link is actually up.
 
 ---
 
@@ -17,18 +39,64 @@ To enable this feature, check the **Cellular** option under **Enabled Features**
 
 ### Sensors
 
-| Entity | Description | API Source |
-| --- | --- | --- |
-| **Cellular WAN IPv4** | The IP address assigned to the cellular internet interface. Hidden when cellular internet is unavailable. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular WAN IPv6** | The IPv6 address assigned to the cellular internet interface. Hidden when cellular internet is unavailable. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular signal** | Overall cellular signal strength percentage. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular RSSI** | Received Signal Strength Indicator in dBm. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular RSRP** | Reference Signal Received Power in dBm. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular RSRQ** | Reference Signal Received Quality in dB. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular SINR** | Signal-to-Interference-plus-Noise Ratio in dB. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular band** | Active frequency band / service type (e.g., LTE Band 4). | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular network** | Active mobile network operator name and connection mode. | `modem/get_status` or 4.9+ normalized modem status |
-| **Cellular APN** | Access Point Name used for the cellular connection. | `modem/get_status` or 4.9+ normalized modem status |
+| Entity | Description | 4.8 source | 4.9+ source |
+| --- | --- | --- | --- |
+| **Cellular WAN IPv4** | The IP address assigned to the cellular internet interface. Hidden when cellular internet is unavailable. | `modem.get_status` → `modems[].network.ipv4.ip` | Bodyless `modem/get_network_info` → `networks[].ipv4.ip` (per active SIM slot). |
+| **Cellular WAN IPv6** | The IPv6 address assigned to the cellular internet interface. Hidden when cellular internet is unavailable. | `modem.get_status` → `modems[].network.ipv6.ip` | Bodyless `modem/get_network_info` → `networks[].ipv6.ip`. |
+| **Cellular APN** | Access Point Name used for the cellular connection. | `modem.get_status` → `modems[].simcard.apn` | Per-bus `modem/get_sim_config` → ICCID-keyed record → `apn`. |
+| **Cellular band** | Active frequency band / service type (e.g., `LTE Band 4`). | `modem.get_status` → `modems[].simcard.band` | `modem.get_status` → `modems[].simcard.band` (preserved in 4.9 normalised status). |
+| **Cellular RSRP** | Reference Signal Received Power in dBm. | `modem.get_status` → `modems[].simcard.signal.rsrp` | `modem.get_status` → `modems[].simcard.signal.rsrp`. |
+| **Cellular RSRQ** | Reference Signal Received Quality in dB. | `modem.get_status` → `modems[].simcard.signal.rsrq` | `modem.get_status` → `modems[].simcard.signal.rsrq`. |
+| **Cellular SINR** | Signal-to-Interference-plus-Noise Ratio in dB. | `modem.get_status` → `modems[].simcard.signal.sinr` | `modem.get_status` → `modems[].simcard.signal.sinr`. |
+
+> **Removed sensors**: `Cellular signal`, `Cellular RSSI`, and `Cellular network` are no longer registered. The 4.9 firmware no longer surfaces the underlying values for the first two, and `Cellular network` duplicated `Cellular band`. The `Cellular band` sensor above is the canonical replacement.
+
+### WAN Status Sensors
+
+A `WanStatusSensor` is created for every interface in the `kmwan/get_status` response that you monitor (see the **Wan Status Monitors** option in the integration configuration).
+
+On firmware 4.8 there is a single `Cellular status` sensor backed by the `modem_0001` interface.
+
+On firmware 4.9 there are additional per-slot sensors:
+- `Cellular status` — backed by `modem_0001` (the aggregate). The integration resolves this to the active per-slot interface (`modem_0001_s1` or `modem_0001_s2`) so the sensor correctly shows Up when the cellular link is up.
+- `Cellular SIM 1 status` — backed by `modem_0001_s1`.
+- `Cellular SIM 2 status` — backed by `modem_0001_s2`.
+
+The `Cellular status` sensor's `extra_state_attributes` include:
+- `interface` — the actual interface name the sensor read from (e.g. `modem_0001_s1` on 4.9+, `modem_0001` on 4.8).
+- `interface_name` — the display label (e.g. `Cellular SIM 1`).
+- `requested_interface` — the original interface name the sensor was registered with (always `modem_0001` for the cellular status sensor).
+- `ipv4_status` / `ipv6_status` — the human-readable Up/Down/Unknown per protocol.
+- `status_v4` / `status_v6` — the raw firmware values (`0` = Up, `1` = Down).
+
+---
+
+## 4.9+ Modem Data Flow
+
+Each `fetch_cellular_status` refresh issues the following JSON-RPC calls (4.9 firmware only):
+
+| # | Method | Body | Purpose |
+| --- | --- | --- | --- |
+| 1 | `modem/get_modem_current_interface` | `{}` | Discovers the active SIM targets (`modem_0001_s1`, `modem_0001_s2`). |
+| 2 | `modem/get_signals` | `{"time": 10}` | Rolling signal-strength history per slot (used for the band/RSSI/strength metrics). |
+| 3 | `modem/get_network_status` | `{}` (bodyless) | Aggregated dial / status info for every active network. |
+| 4 | `modem/get_network_info` | `{}` (bodyless) | Per-slot IPv4/IPv6 lease + cell-info (band, RSRP, RSRQ, SINR, mode). |
+| 5 | `modem/get_sim_config` (per bus) | `{"bus": "0001:01:00.0"}` | ICCID-keyed SIM records carrying the APN. One call per distinct modem bus. |
+
+Steps 3 and 4 use the bodyless form on 4.9 — the response carries a `networks` array with one entry per active slot, indexed by `(bus, slot)`. The integration tries every bus alias for each target so the short logical bus (`0001`) and the full PCI bus (`0001:01:00.0`) both resolve to the same modem record.
+
+If the bodyless call returns no entries for a target, the integration falls back to the per-target request shape (`{"bus": ..., "slot": ...}`) so older 4.9 builds that haven't flipped the endpoint still work.
+
+---
+
+## Migration Notes (4.8 → 4.9+)
+
+When upgrading from firmware 4.8 to 4.9, the following entity-registry changes happen automatically on the next Home Assistant reload:
+
+- **`Cellular signal`**, **`Cellular RSSI`**, **`Cellular network`** — removed from the entity registry. These sensors are no longer registered, and any existing entities from a prior 4.8 install are cleaned up by the hub's `async_initialize_hub` pass.
+- **`Cellular status`** — the unique_id is unchanged (`glinet_sensor/<device_mac>/wan_status_modem_0001`), so the existing entity keeps its history. On 4.9+ the sensor now resolves to the active per-slot interface and reports the real Up/Down state.
+- **`Cellular WAN IPv4` / `Cellular WAN IPv6`** — the unique_ids are unchanged, and the IP values are now sourced from the bodyless `modem/get_network_info` call.
+- **`Cellular APN`** — the unique_id is unchanged, and the APN is now sourced from `modem/get_sim_config` on 4.9+.
 
 ---
 

--- a/docs/ci-release.md
+++ b/docs/ci-release.md
@@ -32,3 +32,7 @@ v<manifest-version>
 ```
 
 The release job runs CI first, builds a HACS-friendly zip containing `custom_components/glinet_router`, asks GitHub Models to generate release notes via `actions/ai-inference`, then publishes a GitHub release. If GitHub Models is not available, the workflow falls back to commit-based release notes.
+
+## Related Pages
+
+- [Developer Reference](developer-reference.md) — Contributing, tooling, and project structure.

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1,0 +1,30 @@
+# Conditions
+
+This integration does **not** provide any custom condition platform (e.g. integration-level conditions that wrap router state).
+
+You can use Home Assistant's built-in conditions in your automations, such as `state`, `template`, `numeric_state`, or `time`, against the entities this integration exposes. For example, condition a notification on the `binary_sensor.repeater_connected` entity, or on a `sensor.cpu_temp` value.
+
+## Examples
+
+### State condition
+
+```yaml
+condition:
+  - condition: state
+    entity_id: binary_sensor.repeater_connected
+    state: "on"
+```
+
+### Numeric state condition
+
+```yaml
+condition:
+  - condition: numeric_state
+    entity_id: sensor.cpu_temp
+    above: 70
+```
+
+## Related Pages
+
+- [Triggers](triggers.md)
+- [Services & Actions parent page](services.md)

--- a/docs/core-binary-sensors.md
+++ b/docs/core-binary-sensors.md
@@ -1,0 +1,23 @@
+# Core Binary Sensors
+
+The integration exposes core binary sensors. Some are always available, while others depend on optional features.
+
+## Always Available
+
+| Entity | Source | Notes |
+| --- | --- | --- |
+| **Fan status** | `fan/get_status` | `True` when the fan is currently running. Available on routers with a fan. |
+
+## Feature-Gated
+
+| Entity | Source | Notes |
+| --- | --- | --- |
+| **Repeater connected** | `repeater/get_status` | `True` when the repeater is connected or WAN is available. Available when the Repeater feature is enabled. Attributes include SSID, BSSID, signal, WiFi generation, EAP, and bare mode. |
+| **Repeater bare mode** | `repeater/get_status` | Diagnostic sensor. `True` when repeater bare mode is active. Available when the Repeater feature is enabled. |
+| **Parental control group override** | `parental-control/get_status` | One diagnostic binary sensor per parental group. `True` when a temporary override is currently active for that group. Available when the Parental & Access Control feature is enabled. |
+
+## Related Pages
+
+- [Entity Reference parent page](entities.md)
+- [System Sensors](system-sensors.md) — CPU, load, memory, flash, and WAN status sensors.
+- [Core Switches](core-switches.md) — WiFi and LED core switches.

--- a/docs/core-switches.md
+++ b/docs/core-switches.md
@@ -1,0 +1,14 @@
+# Core Switches
+
+The integration exposes two core switches that are always available regardless of optional feature selection.
+
+| Entity | Source | Notes |
+| --- | --- | --- |
+| **WiFi interface switches** | `wifi/get_config`, `wifi/set_config` | One switch per WiFi interface reported by the router. |
+| **System LED** | `led/get_config`, `led/set_config` | Toggle the system status LED. |
+
+## Related Pages
+
+- [Entity Reference parent page](entities.md)
+- [System Sensors](system-sensors.md) — CPU, load, memory, flash, and WAN status sensors.
+- [Binary Sensors](core-binary-sensors.md) — Fan status, repeater, and parental override sensors.

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -68,3 +68,11 @@ python -m ruff format custom_components tests
 
 ### Dependencies
 Do not add massive third-party library dependencies unless absolutely necessary. Home Assistant integrations should remain lightweight. The core integration relies only on `aiohttp` (which is native to HA).
+
+## Related Pages
+
+- [Architecture](architecture.md) — How the integration is structured and interacts with Home Assistant.
+- [Runtime State & Poller (Hub)](hub.md) — Details on the `GLinetHub` and `DataUpdateCoordinator`.
+- [Router API Notes](router-api.md) — Endpoints, authentication, and module inventory.
+- [Modem API Coverage](modem-api.md) — Details on the optional cellular modem API.
+- [CI and Release Workflows](ci-release.md) — How automated testing and releases work.

--- a/docs/device-trackers.md
+++ b/docs/device-trackers.md
@@ -1,0 +1,32 @@
+# Device Trackers
+
+Device trackers are created from online devices returned by the router API.
+
+## Behavior
+
+Trackers are created **only if the device is already known to Home Assistant** through another integration (e.g., the Mobile App, ESPHome, Zigbee, etc.). This prevents the integration from automatically adding every guest device, transient client, or unknown IoT device on your network as a new tracker entity.
+
+However, you can enable the **Discover unknown devices** option during integration setup or in the options flow. When enabled, the integration tracks every device seen by the router, regardless of its status in the Home Assistant device registry.
+
+To restrict which unknown devices are discovered, you can use the **Unknown Devices Filter Mode** (whitelist or blacklist). You can select devices from the dropdown (available in the options flow) or manually specify MAC addresses.
+
+## Tracked Data
+
+The tracker monitors:
+
+- MAC address
+- Name/alias
+- IP address while online
+- Interface type
+- Last activity timestamp
+
+Tracked devices use a `consider_home` logic (default 180s) to prevent entities from flickering to "Away" during brief client sleep cycles or router re-polls. Unhelpful tracker entities can be managed via the standard entity settings in **Settings → Devices & services**.
+
+## Randomized MAC Addresses
+
+If a device uses randomized MAC addresses, Home Assistant may see each randomized address as a separate tracker. Disable private/random MAC addressing for that WiFi network when you want stable tracking.
+
+## Related Pages
+
+- [Entity Reference parent page](entities.md)
+- [Unknown Devices](unknown-devices.md) — Allow/blocklist controls for unknown devices.

--- a/docs/dmz.md
+++ b/docs/dmz.md
@@ -1,0 +1,36 @@
+# DMZ (Optional Feature)
+
+The **DMZ** (DeMilitarized Zone) feature lets you toggle the router's DMZ mode and configure the internal destination IP address. When DMZ is enabled, all inbound traffic from the WAN that is not matched by another rule is forwarded to the configured host.
+
+## Setup Configuration
+
+To enable this feature, check the **Firewall** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `firewall`
+
+## Switches
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **Firewall DMZ** | Toggle the DMZ feature. The `destination_ip` attribute shows the currently configured target IP. | `firewall/set_dmz` |
+
+## Actions (Services)
+
+The following service is registered under the `glinet_router` domain when the Firewall feature is enabled:
+
+### `set_dmz`
+
+Configures DMZ settings.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `enabled` | boolean | Yes | Whether DMZ is enabled. |
+| `dest_ip` | string | No | The internal IP address to expose. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Firewall Rules](firewall-rules.md) — Add and remove custom firewall rules.
+- [Port Forwards](port-forwards.md) — Add and remove port forwarding rules.
+- [WAN Access](wan-access.md) — Toggle WAN ping, HTTPS, and SSH access.
+- [Firewall parent page](firewall.md)

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,116 +1,33 @@
-# Entity Reference (`entities/`)
+# Entity Reference
 
-This page documents the **core** entities exposed by the GL.iNet integration. Core entities are always registered regardless of your optional feature selection.
+This page indexes the **core** entities exposed by the GL.iNet integration. Core entities are always registered regardless of your optional feature selection.
 
 For entities related to optional features, visit their respective pages:
 
 | Optional Feature | Wiki Page |
 | --- | --- |
-| Cellular sensors | [Cellular](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/cellular) |
-| Repeater sensors, switches, selects & binary sensors | [Repeater](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/repeater) |
-| SMS sensor | [SMS](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/sms) |
-| Tailscale switch | [Tailscale](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/tailscale) |
-| WireGuard client switches | [WireGuard Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-client) |
-| WireGuard server sensor & switch | [WireGuard Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-server) |
-| OpenVPN client switches & location select | [OpenVPN Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-client) |
-| OpenVPN server sensor & switch | [OpenVPN Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-server) |
-| ZeroTier switch | [ZeroTier](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/zerotier) |
-| AdGuard Home switches | [AdGuard Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/adguard-home) |
-| Firewall sensors & switches | [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) |
-| Battery sensors & binary sensor | [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) |
-| MCU OLED (services only — no entities) | [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) |
-| Parental control sensors, switches, selects & binary sensors | [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) |
+| Cellular sensors | [Cellular](cellular.md) |
+| Repeater sensors, switches, selects & binary sensors | [Repeater](repeater.md) |
+| SMS sensor | [SMS](sms.md) |
+| Tailscale switch | [Tailscale](tailscale.md) |
+| WireGuard client switches | [WireGuard Client](wireguard-client.md) |
+| WireGuard server sensor & switch | [WireGuard Server](wireguard-server.md) |
+| OpenVPN client switches | [OpenVPN Client](openvpn-client.md) |
+| OpenVPN server sensor & switch | [OpenVPN Server](openvpn-server.md) |
+| ZeroTier switch | [ZeroTier](zerotier.md) |
+| AdGuard Home switches | [AdGuard Home](adguard-home.md) |
+| Firewall sensors & switches | [Firewall](firewall.md) |
+| Battery sensors & binary sensor | [MCU Battery](mcu-battery.md) |
+| MCU OLED (services only — no entities) | [MCU OLED](mcu-oled.md) |
+| Parental control sensors, switches, selects & binary sensors | [Parental & Access Control](parental-control.md) |
 
----
+## Core Entity Pages
 
-## Buttons
-
-| Entity | Source | Notes |
-| --- | --- | --- |
-| **Reboot** | `system/reboot` | Reboots the router immediately. |
-| **Fan test** | `fan/set_test` | Diagnostic button to run the fan at full speed for 10 seconds. Available on routers with an active fan. |
-
-## Update Entity
-
-| Entity | Source | Notes |
-| --- | --- | --- |
-| **Firmware** | `upgrade/check_firmware_online`, `upgrade/get_config`, `upgrade/upgrade_online` | Native Home Assistant firmware update entity. Shows release notes when available and only exposes install when the router provides the required download metadata. |
-
----
-
-## Device Trackers
-
-Device trackers are created from online devices returned by the router API **only if the device is already known to Home Assistant** through another integration (e.g., the Mobile App, ESPHome, Zigbee, etc.).
-
-This behavior prevents the integration from automatically adding every guest device, transient client, or unknown IoT device on your network as a new tracker entity.
-
-However, you can enable the **Discover unknown devices** option during integration setup or in the options flow. When enabled, the integration tracks every device seen by the router, regardless of its status in the Home Assistant device registry.
-
-To restrict which unknown devices are discovered, you can use the **Unknown Devices Filter Mode** (whitelist or blacklist). You can select devices from the dropdown (available in the options flow) or manually specify MAC addresses.
-
-The tracker monitors:
-
-- MAC address
-- Name/alias
-- IP address while online
-- Interface type
-- Last activity timestamp
-
-Tracked devices use a `consider_home` logic (default 180s) to prevent entities from flickering to "Away" during brief client sleep cycles or router re-polls. Unhelpful tracker entities can be managed via the standard entity settings in **Settings → Devices & services**.
-
-If a device uses randomized MAC addresses, Home Assistant may see each randomized address as a separate tracker. Disable private/random MAC addressing for that WiFi network when you want stable tracking.
-
----
-
-## Sensors
-
-### Router Diagnostics
-
-| Entity | Source | Notes |
-| --- | --- | --- |
-| **CPU temperature** | `system/get_status` | Diagnostic sensor. Available when supported by the router. |
-| **Load avg (1m)** | `system/get_status` | Diagnostic sensor. |
-| **Load avg (5m)** | `system/get_status` | Diagnostic sensor. |
-| **Load avg (15m)** | `system/get_status` | Diagnostic sensor. |
-| **Memory usage** | `system/get_status` | Calculated from total/free memory. |
-| **Flash usage** | `system/get_status` | Calculated from total/free flash. |
-| **Uptime** | `system/get_status` | Timestamp sensor. |
-| **Fan speed** | `fan/get_status` | Diagnostic sensor showing current fan RPM. Available on routers with a fan. |
-| **Fan threshold temperature** | `fan/get_config` | Diagnostic sensor showing the current fan temperature threshold. Available on routers with a fan. |
-
-### Internet and Traffic
-
-| Entity | Source | Notes |
-| --- | --- | --- |
-| **WAN status (per interface)** | `edgerouter/get_status` | One sensor per detected WAN interface (e.g., Ethernet 1, Ethernet 2, Repeater, Cellular, Tethering). Reports `Up`, `Down`, or `Unknown`. Specific interfaces and protocols (IPv4/IPv6) can be configured via the **WAN Status Monitors** option in the options flow. |
-| **Connected clients** | `clients/get_online` | Count of currently online tracked clients. |
-
-### Client Bandwidth
-
-Each tracked client includes real-time diagnostic sensors attached to the client device:
-
-- **Download rate** — current download bandwidth.
-- **Upload rate** — current upload bandwidth.
-- **IP address** — current IP address of the client.
-
-These sensors are created only when the router reports bandwidth fields in the client list. Rates are calculated from delta changes between polls when explicit rate fields are missing.
-
----
-
-## Switches
-
-| Entity | Source | Notes |
-| --- | --- | --- |
-| **WiFi interface switches** | `wifi/get_config`, `wifi/set_config` | One switch per WiFi interface reported by the router. |
-| **System LED** | `led/get_config`, `led/set_config` | Toggle the system status LED. |
-
----
-
-## Binary Sensors
-
-| Entity | Source | Notes |
-| --- | --- | --- |
-| **Fan status** | `fan/get_status` | `True` when the fan is currently running. Available on routers with a fan. |
-| **Repeater connected** | `repeater/get_status` | `True` when the repeater is connected or WAN is available. Available when the Repeater feature is enabled. Attributes include SSID, BSSID, signal, WiFi generation, EAP, and bare mode. |
-| **Repeater bare mode** | `repeater/get_status` | Diagnostic sensor. `True` when repeater bare mode is active. Available when the Repeater feature is enabled. |
-| **Parental control group override** | `parental-control/get_status` | One diagnostic binary sensor per parental group. `True` when a temporary override is currently active for that group. Available when the Parental & Access Control feature is enabled. |
+| Page | Description |
+| --- | --- |
+| [Buttons](buttons.md) | Reboot and fan test buttons. |
+| [Firmware Update](update-entity.md) | Native Home Assistant firmware update entity. |
+| [Device Trackers](device-trackers.md) | Per-client device tracking. |
+| [System Sensors](system-sensors.md) | CPU, load, memory, flash, WAN status, and client bandwidth sensors. |
+| [Core Switches](core-switches.md) | WiFi interface and system LED switches. |
+| [Core Binary Sensors](core-binary-sensors.md) | Fan status and other core binary sensors. |

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -30,4 +30,4 @@ For entities related to optional features, visit their respective pages:
 | [Device Trackers](device-trackers.md) | Per-client device tracking. |
 | [System Sensors](system-sensors.md) | CPU, load, memory, flash, WAN status, and client bandwidth sensors. |
 | [Core Switches](core-switches.md) | WiFi interface and system LED switches. |
-| [Core Binary Sensors](core-binary-sensors.md) | Fan status and other core binary sensors. |
+

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -6,20 +6,20 @@ For entities related to optional features, visit their respective pages:
 
 | Optional Feature | Wiki Page |
 | --- | --- |
-| Cellular sensors | [Cellular](https://github.com/vithurshanselvarajah/glinet-router/wiki/cellular) |
-| Repeater sensors, switches, selects & binary sensors | [Repeater](https://github.com/vithurshanselvarajah/glinet-router/wiki/repeater) |
-| SMS sensor | [SMS](https://github.com/vithurshanselvarajah/glinet-router/wiki/sms) |
-| Tailscale switch | [Tailscale](https://github.com/vithurshanselvarajah/glinet-router/wiki/tailscale) |
-| WireGuard client switches | [WireGuard Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-client) |
-| WireGuard server sensor & switch | [WireGuard Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-server) |
-| OpenVPN client switches & location select | [OpenVPN Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-client) |
-| OpenVPN server sensor & switch | [OpenVPN Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-server) |
-| ZeroTier switch | [ZeroTier](https://github.com/vithurshanselvarajah/glinet-router/wiki/zerotier) |
-| AdGuard Home switches | [AdGuard Home](https://github.com/vithurshanselvarajah/glinet-router/wiki/adguard-home) |
-| Firewall sensors & switches | [Firewall](https://github.com/vithurshanselvarajah/glinet-router/wiki/firewall) |
-| Battery sensors & binary sensor | [MCU Battery](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-battery) |
-| MCU OLED (services only — no entities) | [MCU OLED](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-oled) |
-| Parental control sensors, switches, selects & binary sensors | [Parental & Access Control](https://github.com/vithurshanselvarajah/glinet-router/wiki/parental-control) |
+| Cellular sensors | [Cellular](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/cellular) |
+| Repeater sensors, switches, selects & binary sensors | [Repeater](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/repeater) |
+| SMS sensor | [SMS](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/sms) |
+| Tailscale switch | [Tailscale](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/tailscale) |
+| WireGuard client switches | [WireGuard Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-client) |
+| WireGuard server sensor & switch | [WireGuard Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-server) |
+| OpenVPN client switches & location select | [OpenVPN Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-client) |
+| OpenVPN server sensor & switch | [OpenVPN Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-server) |
+| ZeroTier switch | [ZeroTier](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/zerotier) |
+| AdGuard Home switches | [AdGuard Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/adguard-home) |
+| Firewall sensors & switches | [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) |
+| Battery sensors & binary sensor | [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) |
+| MCU OLED (services only — no entities) | [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) |
+| Parental control sensors, switches, selects & binary sensors | [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) |
 
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -52,6 +52,7 @@ When adding the GL.iNet integration or modifying it via the **Configure** menu, 
 - **Router URL**: The network address of your router (e.g., `http://192.168.8.1`). HTTPS is supported if configured on the router.
 - **Admin Password**: The password for the `root` account used to access the GL.iNet admin panel.
 - **Update Interval**: The polling frequency in seconds, between 10s and 300s (default 30s). Increase this if you experience router slowdowns.
+- **Faster updates (parallel fetching)**: When enabled, the per-feature API requests are fired concurrently during each coordinator refresh using `asyncio.gather`. This can significantly reduce total refresh time on capable hardware but puts more load on the router — keep it off (the default) for low-powered travel routers. Errors raised by a single fetch are logged and do not abort the rest of the refresh.
 - **Consider Home**: The grace period in seconds before a device is marked as "Away". Prevents devices from flickering when they briefly drop off the network.
 - **Discover unknown devices**: When enabled, adds all newly discovered devices to the Home Assistant device registry rather than only known/tracked ones. Toggling this off automatically cleans up untracked devices.
 - **Auto-cleanup unknown devices (min)**: The inactivity period in minutes after which an untracked device is automatically removed from the registry. Set to `0` to disable.
@@ -77,7 +78,7 @@ The integration is a **local polling** integration (`iot_class: local_polling`) 
 - **Default polling interval**: 30 seconds, controlled by the **Update Interval** option.
 - **Allowed range**: 10–300 seconds. The config flow clamps the value to this range so the user cannot pick a value that would hammer the router.
 - **Coordinator-driven**: All entity platforms (sensors, switches, binary sensors, select, update, device tracker) read their state from a single coordinator update per cycle. This avoids each platform polling independently and keeps router load predictable.
-- **Sequential fetch**: Within a single update, the hub calls each JSON-RPC endpoint one at a time. This is intentional — see **Performance & Load Management** below.
+- **Sequential fetch**: Within a single update, the hub calls each JSON-RPC endpoint one at a time. This is intentional — see **Performance & Load Management** below. Users with capable routers can opt into concurrent execution via the **Faster updates (parallel fetching)** option in the config / options flow.
 - **Throttled firmware check**: Firmware upgrade metadata is refreshed at most once every 24 hours even if the polling interval is much shorter.
 - **Single source of truth for connection health**: A single failed token renewal or transient timeout does not stop the rest of the cycle. Errors are caught at the request boundary, surfaced through `UpdateFailed`, and the coordinator retries at the next interval.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # Feature Matrix & Supported Actions
 
-This page provides an overview of the core features always provided by the GL.iNet integration. Optional features are documented on their own dedicated pages — see the [Home](https://github.com/vithurshanselvarajah/glinet-router/wiki/Home) page for the full list.
+This page provides an overview of the core features always provided by the GL.iNet integration. Optional features are documented on their own dedicated pages — see the [Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/Home) page for the full list.
 
 ## Core Features
 
@@ -16,7 +16,7 @@ The following capabilities are always available regardless of optional feature s
 - **Device Tracking**: Monitors connected clients — MAC address, name/alias, IP address, interface type, and last-seen timestamp. Includes a cleanup mechanism for stale offline devices.
 - **Connected Clients Count**: Sensor showing total currently active tracked clients.
 - **Client Diagnostics**: Per-client download rate, upload rate, and IP address sensors attached to each tracked client device.
-- **Unknown Device Management**: Discover unknown devices, auto-cleanup rules, allow/blocklist controls, and manual MAC address entries. See [Unknown Device Management](https://github.com/vithurshanselvarajah/glinet-router/wiki/unknown-devices).
+- **Unknown Device Management**: Discover unknown devices, auto-cleanup rules, allow/blocklist controls, and manual MAC address entries. See [Unknown Device Management](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/unknown-devices).
 - **Firmware Updates**: Native Home Assistant firmware update entity with release notes when the router exposes them.
 - **Sanitized Diagnostics**: Safe diagnostic downloads masking sensitive data (MAC addresses, WiFi passwords, session IDs, and tokens).
 
@@ -24,24 +24,24 @@ The following capabilities are always available regardless of optional feature s
 
 The integration treats several advanced capabilities as optional modules selectable during setup or via the **Configure** menu:
 
-- [Cellular](https://github.com/vithurshanselvarajah/glinet-router/wiki/cellular) - Monitor cellular connection, signals, and modem diagnostics.
-- [Repeater](https://github.com/vithurshanselvarajah/glinet-router/wiki/repeater) - Connect to and scan for external WiFi networks, manage saved networks.
-- [SMS](https://github.com/vithurshanselvarajah/glinet-router/wiki/sms) - Send, receive, and delete text messages.
-- [Tailscale](https://github.com/vithurshanselvarajah/glinet-router/wiki/tailscale) - Enable or disable Tailscale integration.
-- [WireGuard Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-client) - Toggle configured WireGuard client profiles.
-- [WireGuard Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/wireguard-server) - Manage the built-in WireGuard server.
-- [OpenVPN Client](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-client) - Manage and select OpenVPN client configurations.
-- [OpenVPN Server](https://github.com/vithurshanselvarajah/glinet-router/wiki/openvpn-server) - Manage the built-in OpenVPN server.
-- [ZeroTier](https://github.com/vithurshanselvarajah/glinet-router/wiki/zerotier) - Enable or disable ZeroTier VPN connections.
-- [AdGuard Home](https://github.com/vithurshanselvarajah/glinet-router/wiki/adguard-home) - Enable/disable AdGuard Home and DNS redirection.
-- [KMWAN](https://github.com/vithurshanselvarajah/glinet-router/wiki/router-api) - Read and update GL.iNet's KMWAN multi-WAN configuration through actions.
-- [MWAN3](https://github.com/vithurshanselvarajah/glinet-router/wiki/router-api) - Read and update MWAN3 multi-WAN configuration through actions.
-- [Firewall](https://github.com/vithurshanselvarajah/glinet-router/wiki/firewall) - Manage firewall rules, port forwarding, and DMZ settings.
-- [Smart Fan Controls](https://github.com/vithurshanselvarajah/glinet-router/wiki/smart-fan) - Monitor fan status, speed, and set temperature thresholds.
-- [MCU Battery](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-battery) - Monitor battery status and configure high/low temperature warnings.
-- [MCU OLED](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-oled) - Configure what is displayed on the router's OLED screen.
-- [Parental & Access Control](https://github.com/vithurshanselvarajah/glinet-router/wiki/parental-control) - Manage internet access blocks and parental group rules per client.
-- [API Playground](https://github.com/vithurshanselvarajah/glinet-router/wiki/playground) - Send custom JSON-RPC or ubus commands and inspect the response.
+- [Cellular](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/cellular) - Monitor cellular connection, signals, and modem diagnostics.
+- [Repeater](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/repeater) - Connect to and scan for external WiFi networks, manage saved networks.
+- [SMS](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/sms) - Send, receive, and delete text messages.
+- [Tailscale](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/tailscale) - Enable or disable Tailscale integration.
+- [WireGuard Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-client) - Toggle configured WireGuard client profiles.
+- [WireGuard Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/wireguard-server) - Manage the built-in WireGuard server.
+- [OpenVPN Client](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-client) - Manage and select OpenVPN client configurations.
+- [OpenVPN Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-server) - Manage the built-in OpenVPN server.
+- [ZeroTier](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/zerotier) - Enable or disable ZeroTier VPN connections.
+- [AdGuard Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/adguard-home) - Enable/disable AdGuard Home and DNS redirection.
+- [KMWAN](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) - Read and update GL.iNet's KMWAN multi-WAN configuration through actions.
+- [MWAN3](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) - Read and update MWAN3 multi-WAN configuration through actions.
+- [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) - Manage firewall rules, port forwarding, and DMZ settings.
+- [Smart Fan Controls](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) - Monitor fan status, speed, and set temperature thresholds.
+- [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) - Monitor battery status and configure high/low temperature warnings.
+- [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) - Configure what is displayed on the router's OLED screen.
+- [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) - Manage internet access blocks and parental group rules per client.
+- [API Playground](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground) - Send custom JSON-RPC or ubus commands and inspect the response.
 
 If you disable all optional features, the integration still registers all core router status sensors and entities.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,10 +34,10 @@ The integration treats several advanced capabilities as optional modules selecta
 - [OpenVPN Server](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/openvpn-server) - Manage the built-in OpenVPN server.
 - [ZeroTier](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/zerotier) - Enable or disable ZeroTier VPN connections.
 - [AdGuard Home](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/adguard-home) - Enable/disable AdGuard Home and DNS redirection.
-- [KMWAN](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) - Read and update GL.iNet's KMWAN multi-WAN configuration through actions.
-- [MWAN3](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) - Read and update MWAN3 multi-WAN configuration through actions.
+- [KMWAN](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/kmwan) - Read and update GL.iNet's KMWAN multi-WAN configuration through actions.
+- [MWAN3](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mwan3) - Read and update MWAN3 multi-WAN configuration through actions.
 - [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) - Manage firewall rules, port forwarding, and DMZ settings.
-- [Smart Fan Controls](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) - Monitor fan status, speed, and set temperature thresholds.
+- [Smart Fan](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) - Monitor fan status, speed, and set temperature thresholds.
 - [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) - Monitor battery status and configure high/low temperature warnings.
 - [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) - Configure what is displayed on the router's OLED screen.
 - [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) - Manage internet access blocks and parental group rules per client.
@@ -69,6 +69,19 @@ To ensure reliable communication and minimise session expiration issues:
 - **Retry Mechanism**: Token renewal is retried up to 3 times on authentication or token errors.
 - **Detailed Logging**: Failed renewals log the specific error response or exception for easier troubleshooting.
 - **Graceful Failure**: If all retries fail, a re-authentication flow is triggered in Home Assistant to prompt the user for credentials.
+
+## Polling
+
+The integration is a **local polling** integration (`iot_class: local_polling`) and uses Home Assistant's `DataUpdateCoordinator` to refresh router state on a single, user-configurable interval.
+
+- **Default polling interval**: 30 seconds, controlled by the **Update Interval** option.
+- **Allowed range**: 10–300 seconds. The config flow clamps the value to this range so the user cannot pick a value that would hammer the router.
+- **Coordinator-driven**: All entity platforms (sensors, switches, binary sensors, select, update, device tracker) read their state from a single coordinator update per cycle. This avoids each platform polling independently and keeps router load predictable.
+- **Sequential fetch**: Within a single update, the hub calls each JSON-RPC endpoint one at a time. This is intentional — see **Performance & Load Management** below.
+- **Throttled firmware check**: Firmware upgrade metadata is refreshed at most once every 24 hours even if the polling interval is much shorter.
+- **Single source of truth for connection health**: A single failed token renewal or transient timeout does not stop the rest of the cycle. Errors are caught at the request boundary, surfaced through `UpdateFailed`, and the coordinator retries at the next interval.
+
+If you have a slow router (e.g., a low-end travel router) or you see timeouts in the log, raise the **Update Interval** to 60–120 seconds. If you want near-real-time device tracking, lower it to 10–15 seconds — but be aware this increases the number of JSON-RPC calls per minute.
 
 ## Performance & Load Management
 

--- a/docs/firewall-rules.md
+++ b/docs/firewall-rules.md
@@ -1,0 +1,66 @@
+# Firewall Rules (Optional Feature)
+
+The **Firewall Rules** feature lets you add and remove custom firewall rules on your GL.iNet router. Rules are evaluated by the router's standard firewall pipeline.
+
+## Setup Configuration
+
+To enable this feature, check the **Firewall** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `firewall`
+
+> Disabling this feature also removes the `Firewall rules` sensor and the related port forwarding entities.
+
+## Sensors
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **Firewall rules** | Count of active custom firewall rules. | `firewall/get_rules` |
+
+## Actions (Services)
+
+The following services are registered under the `glinet_router` domain when the Firewall feature is enabled:
+
+### `add_firewall_rule`
+
+Adds a custom firewall rule.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | Yes | Descriptive name for the rule. |
+| `src` | string | Yes | Source zone (e.g., `wan`, `lan`). |
+| `src_ip` | string | No | Source IP address. |
+| `src_mac` | string | No | Source MAC address. |
+| `src_port` | string | No | Source port. |
+| `proto` | string | Yes | Protocol (`tcp`, `udp`, `tcpudp`). |
+| `dest` | string | Yes | Destination zone. |
+| `dest_ip` | string | No | Destination IP address. |
+| `dest_port` | string | No | Destination port. |
+| `target` | string | Yes | Target action (`ACCEPT`, `DROP`, `REJECT`). |
+| `enabled` | boolean | No | Whether the rule is active. Defaults to `true`. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `remove_firewall_rule`
+
+Removes a firewall rule.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `rule_id` | string | Yes | The ID of the rule to remove. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `get_firewall_rules`
+
+Returns configured firewall rules as action response data.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+**Response**: `rules` array, each item containing `id` and `name`.
+
+## Related Pages
+
+- [Port Forwards](port-forwards.md) — Add and remove port forwarding rules.
+- [DMZ](dmz.md) — Toggle the DMZ feature.
+- [WAN Access](wan-access.md) — Toggle WAN ping, HTTPS, and SSH access.
+- [Firewall parent page](firewall.md)

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -1,6 +1,6 @@
 # Firewall (Optional Feature)
 
-The **Firewall** feature allows you to monitor firewall rule and port forward counts, manage DMZ and WAN access toggles, and add/remove custom rules.
+The **Firewall** feature groups together everything related to the GL.iNet router's firewall: custom rules, port forwarding, the DMZ toggle, and remote WAN access settings. Each sub-feature is documented on its own page.
 
 ## Setup Configuration
 
@@ -8,86 +8,13 @@ To enable this feature, check the **Firewall** option under **Enabled Features**
 
 - **Option key**: `firewall`
 
-> **Note**: Disabling this feature also removes all port forwarding entities, avoiding orphaned `port_forwards` sensors.
+> Disabling this feature removes all firewall-related sensors, switches, and services from the registry.
 
----
+## Sub-Features
 
-## Exposed Entities
-
-### Sensors
-
-| Entity | Description | API Source |
-| --- | --- | --- |
-| **Firewall rules** | Count of active custom firewall rules. | `firewall/get_rules` |
-| **Port forwards** | Count of active port forwarding rules. | `firewall/get_port_forwards` |
-
-### Switches
-
-| Entity | Description | API Source |
-| --- | --- | --- |
-| **Firewall DMZ** | Toggle the DMZ (DeMilitarized Zone) feature. | `firewall/set_dmz` |
-| **WAN Ping Access** | Toggle whether the router responds to ICMP echo requests from the WAN. | `firewall/set_wan_access` |
-| **WAN HTTPS Access** | Toggle remote HTTPS management access from the WAN. | `firewall/set_wan_access` |
-| **WAN SSH Access** | Toggle remote SSH management access from the WAN. | `firewall/set_wan_access` |
-
----
-
-## Actions (Services)
-
-The following services are registered under the `glinet_router` domain when the Firewall feature is enabled:
-
-### `add_firewall_rule`
-Adds a custom firewall rule.
-
-- **`name`**: Descriptive name for the rule.
-- **`src`**: Source zone (e.g., `wan`, `lan`).
-- **`src_ip`** (Optional): Source IP address.
-- **`src_mac`** (Optional): Source MAC address.
-- **`src_port`** (Optional): Source port.
-- **`proto`**: Protocol (`tcp`, `udp`, `tcpudp`).
-- **`dest`**: Destination zone.
-- **`dest_ip`** (Optional): Destination IP address.
-- **`dest_port`** (Optional): Destination port.
-- **`target`**: Target action (`ACCEPT`, `DROP`, `REJECT`).
-- **`enabled`**: Whether the rule is active.
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `remove_firewall_rule`
-Removes a firewall rule.
-
-- **`rule_id`**: The ID of the rule to remove.
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `get_firewall_rules`
-Returns configured firewall rules as action response data.
-
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-**Response**: `rules` array, each item containing `id` and `name`.
-
-### `add_port_forward`
-Adds a port forwarding rule.
-
-- **`name`**: Descriptive name.
-- **`src`**: Source zone (usually `wan`).
-- **`src_dport`**: External port.
-- **`proto`**: Protocol.
-- **`dest`**: Destination zone (usually `lan`).
-- **`dest_ip`**: Internal IP address.
-- **`dest_port`**: Internal port.
-- **`enabled`**: Whether the rule is active.
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `remove_port_forward`
-Removes a port forwarding rule.
-
-- **`rule_id`** (Optional): The ID of the rule to remove.
-- **`remove_all`** (Optional): If `true`, removes all port forwarding rules.
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `set_dmz`
-Configures DMZ settings.
-
-- **`enabled`**: Whether DMZ is enabled.
-- **`dest_ip`** (Optional): The internal IP address to expose.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Page | Description |
+| --- | --- |
+| [Firewall Rules](firewall-rules.md) | Add and remove custom firewall rules. |
+| [Port Forwards](port-forwards.md) | Add and remove port forwarding rules. |
+| [DMZ](dmz.md) | Toggle the DMZ and configure the target IP. |
+| [WAN Access](wan-access.md) | Toggle WAN ping, HTTPS, and SSH remote access. |

--- a/docs/hub-action-functions.md
+++ b/docs/hub-action-functions.md
@@ -1,0 +1,56 @@
+# Hub Action Functions
+
+Action methods perform a write to the router or trigger a router-side behavior. Most are called from a Home Assistant service handler or entity's `async_turn_on` / `async_turn_off` hook.
+
+| Function | Purpose |
+| --- | --- |
+| `reboot` | Triggers a router reboot. |
+| `set_wifi_interface_enabled` | Enables or disables a WiFi interface. |
+| `start_vpn_client` / `stop_vpn_client` | Controls WireGuard client connections. |
+| `start_wg_server` / `stop_wg_server` | Controls the WireGuard server. |
+| `start_ovpn_client` / `stop_ovpn_client` / `stop_all_ovpns` | Controls OpenVPN client connections. |
+| `start_ovpn_server` / `stop_ovpn_server` | Controls the OpenVPN server. |
+| `connect_tailscale` / `disconnect_tailscale` | Controls the Tailscale connection. |
+| `start_zerotier` / `stop_zerotier` | Controls the ZeroTier connection. |
+| `set_led_enabled` | Controls the system LED. |
+| `set_adguard_enabled` / `set_adguard_dns_enabled` | Controls AdGuard Home functionality. |
+| `add_firewall_rule` / `remove_firewall_rule` | Adds or removes a custom firewall rule. |
+| `get_firewall_rule_summaries` | Returns a list of `{id, name}` dicts for all current firewall rules. |
+| `add_port_forward` / `remove_port_forward` | Adds or removes a port forwarding rule. |
+| `set_dmz_config` | Enables or disables the DMZ and optionally sets the target IP. |
+| `set_wan_access` | Updates WAN ping/HTTPS/SSH access settings. |
+| `set_fan_temperature` | Sets the fan activation temperature threshold. |
+| `test_fan` | Runs the fan at full speed for a short diagnostic test. |
+| `get_kmwan_config` / `get_kmwan_status` / `set_kmwan_config` / `set_kmwan_interface` / `set_kmwan_sensitivity` | Reads and updates KMWAN configuration through the optional WAN policy services. |
+| `get_mwan3_config` / `get_mwan3_status` / `set_mwan3_config` / `set_mwan3_interface` | Reads and updates MWAN3 configuration through the optional WAN policy services. |
+| `upgrade_firmware` | Starts a firmware update using the router's latest online firmware metadata when available. |
+| `send_sms` | Sends an SMS message using the first available SMS-capable modem bus. |
+| `remove_sms` | Deletes SMS messages by scope or specific message ID. |
+| `scan_wifi_networks` | Triggers a site survey and updates the list of available SSIDs. |
+| `connect_to_wifi` | Configures and initiates a repeater connection. |
+| `disconnect_wifi` | Terminates the current repeater connection. |
+| `get_saved_wifi_networks` | Returns the current list of saved repeater AP profiles. |
+| `remove_saved_wifi_network` | Deletes a specific saved profile from the router. |
+| `get_mcu_battery_config` / `set_mcu_battery_config` | Reads or writes battery warning thresholds. |
+| `get_mcu_oled_config` / `set_mcu_oled_config` | Reads or writes OLED screen display settings. |
+| `set_parental_control_enabled` | Globally enables or disables parental controls. |
+| `set_group_enabled` | Enables or disables internet limits for a specific parental group. |
+| `set_temporary_override` | Applies a temporary parental control override to a group. |
+| `set_parental_mode` | Sets the router's parental filtering mode. |
+| `update_parental_signatures` | Triggers a parental control signature database update. |
+| `set_access_control_mode` | Switches between blacklist and whitelist access control modes. |
+| `set_single_device_block` | Blocks or unblocks a specific client device by MAC address. |
+| `set_group_schedules_enabled` | Enables or disables schedule enforcement for a parental group. |
+| `assign_device_to_parental_group` | Moves a client device into a specific parental group. |
+| `set_repeater_auto_switch` | Enables or disables repeater auto-switch between saved networks. |
+| `set_repeater_smart_reconnect` | Enables or disables repeater smart reconnect logic. |
+| `set_repeater_bare_mode` | Enters or exits repeater bare mode. |
+| `set_repeater_band` | Sets the locked wireless band for repeater mode. |
+
+## Related Pages
+
+- [Hub Overview](hub.md)
+- [Hub Core Functions](hub-core.md)
+- [Data Fetching](hub-data-fetching.md)
+- [Option Updates](hub-option-updates.md)
+- [Parental Control Helpers](hub-parental-helpers.md)

--- a/docs/hub-core.md
+++ b/docs/hub-core.md
@@ -1,0 +1,22 @@
+# Hub Core Functions
+
+The `GLinetHub` class inherits from `DataUpdateCoordinator` and manages communication between Home Assistant and the router. It handles the session lifecycle, error handling, and periodic polling (user-configurable, default 30s).
+
+## Core Functions
+
+| Function | Purpose |
+| --- | --- |
+| `_async_update_data` | The entry point for the coordinator update. Triggers `fetch_all_data`. |
+| `async_initialize_hub` | Performs late initialization (fetching model/MAC) and cleans up orphan entities for disabled features. |
+| `refresh_session_token` | Authenticates with the router RPC and updates the active session ID. Retries up to 3 times on failure. |
+| `fetch_all_data` | Sequentially triggers all data update functions listed below. |
+| `_invoke_api` | Internal wrapper for core API calls; handles timeouts, token renewal, and error logging. |
+| `_invoke_optional_api` | Wrapper for API calls that may not exist on all models (e.g., fan, modem). Silently skips on failure. |
+
+## Related Pages
+
+- [Hub Overview](hub.md) — Index of Hub reference pages.
+- [Data Fetching](hub-data-fetching.md) — Per-feature polling functions.
+- [Action Functions](hub-action-functions.md) — Hub action methods.
+- [Option Updates](hub-option-updates.md) — Runtime options handling.
+- [Parental Control Helpers](hub-parental-helpers.md) — Group lookup and access control helpers.

--- a/docs/hub-data-fetching.md
+++ b/docs/hub-data-fetching.md
@@ -1,0 +1,40 @@
+# Hub Data Fetching Functions
+
+These methods are called during the coordinator update cycle to pull data from the router and refresh the cached state.
+
+| Function | Purpose |
+| --- | --- |
+| `fetch_system_status` | Updates CPU temperature, load averages, memory, flash statistics, uptime, and MCU battery data. |
+| `fetch_kmwan_status` | Updates per-interface WAN status (Ethernet, Repeater, Cellular, Tethering) via the `edgerouter` API. |
+| `fetch_upgrade_info` | Pulls the latest firmware check data from the router, using fields such as `current_version`, `current_compile_time`, and `current_type`, along with release notes, upgrade config, and live upgrade status for the update entity. This refresh is performed once every 24 hours rather than on every polling cycle. |
+| `fetch_connected_devices` | Polls the client list and calculates traffic rates for tracked devices. |
+| `fetch_wifi_interfaces` | Retrieves configuration and status for all WiFi radios (2.4GHz, 5GHz, etc.). |
+| `fetch_fan_status` | Retrieves current fan speed, running state, and temperature threshold. |
+| `fetch_led_status` | Retrieves current system LED enabled state. |
+| `fetch_wireguard_clients` | Tracks the connection status and tunnel IDs for WireGuard VPN profiles. |
+| `fetch_wg_server_status` | Retrieves the status and connected peers for the WireGuard server. |
+| `fetch_ovpn_clients` | Tracks the connection status for OpenVPN clients. |
+| `fetch_ovpn_server_status` | Retrieves the status and connected users for the OpenVPN server. |
+| `fetch_tailscale_state` | Monitors the status of the Tailscale service. |
+| `fetch_zerotier_status` | Monitors the status of the ZeroTier service. |
+| `fetch_adguard_status` | Monitors AdGuard Home and DNS status. |
+| `fetch_cellular_status` | Aggregates modem hardware info with live SIM signal/network status. |
+| `fetch_repeater_status` | Updates the connection state, SSID, and signal for WiFi station mode. |
+| `fetch_repeater_config` | Retrieves settings like band locking, auto-switch, and smart reconnect configuration. |
+| `fetch_saved_networks` | Syncs the list of known WiFi access points used for repeater mode. |
+| `fetch_firewall_rules` | Retrieves the list of custom firewall rules. |
+| `fetch_dmz_config` | Retrieves the current DMZ configuration. |
+| `fetch_port_forwards` | Retrieves the list of port forwarding rules. |
+| `fetch_wan_access` | Retrieves WAN ping/HTTPS/SSH access settings. |
+| `fetch_zone_list` | Retrieves the firewall zone list (used for DMZ targeting). |
+| `fetch_parental_control_status` | Retrieves parental control config, group status, and filtering mode. |
+| `fetch_access_control_config` | Retrieves the blacklist/whitelist access control configuration. |
+| `fetch_sms_messages` | Retrieves and parses the SMS inbox into internal models. |
+
+## Related Pages
+
+- [Hub Overview](hub.md)
+- [Hub Core Functions](hub-core.md)
+- [Action Functions](hub-action-functions.md)
+- [Option Updates](hub-option-updates.md)
+- [Parental Control Helpers](hub-parental-helpers.md)

--- a/docs/hub-option-updates.md
+++ b/docs/hub-option-updates.md
@@ -1,0 +1,15 @@
+# Hub Option Updates
+
+These methods are used internally to apply configuration changes to a running hub, e.g. when the user changes options in the integration options flow.
+
+| Function | Purpose |
+| --- | --- |
+| `apply_option_updates` | Merges new options into the running hub, rebuilds the effective settings, and adjusts the polling interval. Returns `True` on success. |
+
+## Related Pages
+
+- [Hub Overview](hub.md)
+- [Hub Core Functions](hub-core.md)
+- [Data Fetching](hub-data-fetching.md)
+- [Action Functions](hub-action-functions.md)
+- [Parental Control Helpers](hub-parental-helpers.md)

--- a/docs/hub-parental-helpers.md
+++ b/docs/hub-parental-helpers.md
@@ -1,0 +1,18 @@
+# Hub Parental Control Helpers
+
+These properties and methods are used internally by entities and service handlers to look up parental groups and check internet access state.
+
+| Property / Method | Purpose |
+| --- | --- |
+| `parental_groups` | Returns a `dict` of `ParentalGroup` objects keyed by group ID. |
+| `parental_group_by_name_or_id` | Looks up a `ParentalGroup` by either its ID or display name (case-insensitive). Returns `None` when no match is found. |
+| `parental_group_for_device` | Returns the `ParentalGroup` that currently contains a given client MAC, or `None`. |
+| `device_internet_access_enabled` | Returns whether a given MAC currently has internet access based on the active access control mode (black/white list). |
+
+## Related Pages
+
+- [Hub Overview](hub.md)
+- [Hub Core Functions](hub-core.md)
+- [Data Fetching](hub-data-fetching.md)
+- [Action Functions](hub-action-functions.md)
+- [Option Updates](hub-option-updates.md)

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -2,91 +2,14 @@
 
 The `GLinetHub` class inherits from `DataUpdateCoordinator` and manages communication between Home Assistant and the router. It handles the session lifecycle, error handling, and periodic polling (user-configurable, default 30s).
 
-## Core Functions
+This page indexes the Hub reference documentation, split by function category.
 
-| Function | Purpose |
+## Pages
+
+| Page | Description |
 | --- | --- |
-| `_async_update_data` | The entry point for the coordinator update. Triggers `fetch_all_data`. |
-| `async_initialize_hub` | Performs late initialization (fetching model/MAC) and cleans up orphan entities for disabled features. |
-| `refresh_session_token` | Authenticates with the router RPC and updates the active session ID. Retries up to 3 times on failure. |
-| `fetch_all_data` | Sequentially triggers all data update functions listed below. |
-| `_invoke_api` | Internal wrapper for core API calls; handles timeouts, token renewal, and error logging. |
-| `_invoke_optional_api` | Wrapper for API calls that may not exist on all models (e.g., fan, modem). Silently skips on failure. |
-
-## Data Fetching Functions
-
-| Function | Purpose |
-| --- | --- |
-| `fetch_system_status` | Updates CPU temperature, load averages, memory, flash statistics, uptime, and MCU battery data. |
-| `fetch_kmwan_status` | Updates per-interface WAN status (Ethernet, Repeater, Cellular, Tethering) via the `edgerouter` API. |
-| `fetch_upgrade_info` | Pulls the latest firmware check data from the router, using fields such as `current_version`, `current_compile_time`, and `current_type`, along with release notes, upgrade config, and live upgrade status for the update entity. This refresh is performed once every 24 hours rather than on every polling cycle. |
-| `fetch_connected_devices` | Polls the client list and calculates traffic rates for tracked devices. |
-| `fetch_wifi_interfaces` | Retrieves configuration and status for all WiFi radios (2.4GHz, 5GHz, etc.). |
-| `fetch_fan_status` | Retrieves current fan speed, running state, and temperature threshold. |
-| `fetch_led_status` | Retrieves current system LED enabled state. |
-| `fetch_wireguard_clients` | Tracks the connection status and tunnel IDs for WireGuard VPN profiles. |
-| `fetch_wg_server_status` | Retrieves the status and connected peers for the WireGuard server. |
-| `fetch_ovpn_clients` | Tracks the connection status for OpenVPN clients. |
-| `fetch_ovpn_server_status` | Retrieves the status and connected users for the OpenVPN server. |
-| `fetch_tailscale_state` | Monitors the status of the Tailscale service. |
-| `fetch_zerotier_status` | Monitors the status of the ZeroTier service. |
-| `fetch_adguard_status` | Monitors AdGuard Home and DNS status. |
-| `fetch_cellular_status` | Aggregates modem hardware info with live SIM signal/network status. |
-| `fetch_repeater_status` | Updates the connection state, SSID, and signal for WiFi station mode. |
-| `fetch_repeater_config` | Retrieves settings like band locking, auto-switch, and smart reconnect configuration. |
-| `fetch_saved_networks` | Syncs the list of known WiFi access points used for repeater mode. |
-| `fetch_firewall_rules` | Retrieves the list of custom firewall rules. |
-| `fetch_dmz_config` | Retrieves the current DMZ configuration. |
-| `fetch_port_forwards` | Retrieves the list of port forwarding rules. |
-| `fetch_wan_access` | Retrieves WAN ping/HTTPS/SSH access settings. |
-| `fetch_zone_list` | Retrieves the firewall zone list (used for DMZ targeting). |
-| `fetch_parental_control_status` | Retrieves parental control config, group status, and filtering mode. |
-| `fetch_access_control_config` | Retrieves the blacklist/whitelist access control configuration. |
-| `fetch_sms_messages` | Retrieves and parses the SMS inbox into internal models. |
-
-## Action Functions
-
-| Function | Purpose |
-| --- | --- |
-| `reboot` | Triggers a router reboot. |
-| `set_wifi_interface_enabled` | Enables or disables a WiFi interface. |
-| `start_vpn_client` / `stop_vpn_client` | Controls WireGuard client connections. |
-| `start_wg_server` / `stop_wg_server` | Controls the WireGuard server. |
-| `start_ovpn_client` / `stop_ovpn_client` / `stop_all_ovpns` | Controls OpenVPN client connections. |
-| `start_ovpn_server` / `stop_ovpn_server` | Controls the OpenVPN server. |
-| `connect_tailscale` / `disconnect_tailscale` | Controls the Tailscale connection. |
-| `start_zerotier` / `stop_zerotier` | Controls the ZeroTier connection. |
-| `set_led_enabled` | Controls the system LED. |
-| `set_adguard_enabled` / `set_adguard_dns_enabled` | Controls AdGuard Home functionality. |
-| `add_firewall_rule` / `remove_firewall_rule` | Adds or removes a custom firewall rule. |
-| `get_firewall_rule_summaries` | Returns a list of `{id, name}` dicts for all current firewall rules. |
-| `add_port_forward` / `remove_port_forward` | Adds or removes a port forwarding rule. |
-| `set_dmz_config` | Enables or disables the DMZ and optionally sets the target IP. |
-| `set_wan_access` | Updates WAN ping/HTTPS/SSH access settings. |
-| `set_fan_temperature` | Sets the fan activation temperature threshold. |
-| `test_fan` | Runs the fan at full speed for a short diagnostic test. |
-| `get_kmwan_config` / `get_kmwan_status` / `set_kmwan_config` / `set_kmwan_interface` / `set_kmwan_sensitivity` | Reads and updates KMWAN configuration through the optional WAN policy services. |
-| `get_mwan3_config` / `get_mwan3_status` / `set_mwan3_config` / `set_mwan3_interface` | Reads and updates MWAN3 configuration through the optional WAN policy services. |
-| `upgrade_firmware` | Starts a firmware update using the router's latest online firmware metadata when available. |
-| `send_sms` | Sends an SMS message using the first available SMS-capable modem bus. |
-| `remove_sms` | Deletes SMS messages by scope or specific message ID. |
-| `scan_wifi_networks` | Triggers a site survey and updates the list of available SSIDs. |
-| `connect_to_wifi` | Configures and initiates a repeater connection. |
-| `disconnect_wifi` | Terminates the current repeater connection. |
-| `get_saved_wifi_networks` | Returns the current list of saved repeater AP profiles. |
-| `remove_saved_wifi_network` | Deletes a specific saved profile from the router. |
-| `get_mcu_battery_config` / `set_mcu_battery_config` | Reads or writes battery warning thresholds. |
-| `get_mcu_oled_config` / `set_mcu_oled_config` | Reads or writes OLED screen display settings. |
-| `set_parental_control_enabled` | Globally enables or disables parental controls. |
-| `set_group_enabled` | Enables or disables internet limits for a specific parental group. |
-| `set_temporary_override` | Applies a temporary parental control override to a group. |
-| `set_parental_mode` | Sets the router's parental filtering mode. |
-| `update_parental_signatures` | Triggers a parental control signature database update. |
-| `set_access_control_mode` | Switches between blacklist and whitelist access control modes. |
-| `set_single_device_block` | Blocks or unblocks a specific client device by MAC address. |
-| `set_group_schedules_enabled` | Enables or disables schedule enforcement for a parental group. |
-| `assign_device_to_parental_group` | Moves a client device into a specific parental group. |
-| `set_repeater_auto_switch` | Enables or disables repeater auto-switch between saved networks. |
-| `set_repeater_smart_reconnect` | Enables or disables repeater smart reconnect logic. |
-| `set_repeater_bare_mode` | Enters or exits repeater bare mode. |
-| `set_repeater_band` | Sets the locked wireless band for repeater mode. |
+| [Hub Core Functions](hub-core.md) | Coordinator lifecycle, session refresh, and API invocation helpers. |
+| [Data Fetching Functions](hub-data-fetching.md) | Per-feature polling methods invoked during each update. |
+| [Action Functions](hub-action-functions.md) | Methods that write to the router or trigger a router-side behavior. |
+| [Option Updates](hub-option-updates.md) | Runtime application of configuration option changes. |
+| [Parental Control Helpers](hub-parental-helpers.md) | Group lookup and access control helper methods. |

--- a/docs/kmwan.md
+++ b/docs/kmwan.md
@@ -1,0 +1,61 @@
+# KMWAN (Optional Feature)
+
+The **KMWAN** feature reads and updates the GL.iNet router's KMWAN multi-WAN configuration through services. KMWAN is GL.iNet's preferred multi-WAN policy engine.
+
+## Setup Configuration
+
+To enable this feature, check the **KMWAN** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `kmwan`
+
+## Actions (Services)
+
+The following services are registered under the `glinet_router` domain when the KMWAN feature is enabled:
+
+### `kmwan_get_config`
+
+Retrieves the current KMWAN configuration from the router. Supports response data.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `kmwan_get_status`
+
+Retrieves the current KMWAN interface status. Supports response data.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `kmwan_set_config`
+
+Updates the KMWAN configuration.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `config` | object | Yes | New KMWAN configuration. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `kmwan_set_interface`
+
+Updates a single KMWAN interface.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `interface` | object | Yes | Interface definition to update. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `kmwan_set_sensitivity`
+
+Updates the KMWAN interface-failure sensitivity.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `sensitivity` | object | Yes | Sensitivity configuration. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [MWAN3](mwan3.md) — Alternative multi-WAN policy engine.
+- [Router API Notes](router-api.md) — Endpoints, authentication, and module inventory.

--- a/docs/mcu-battery.md
+++ b/docs/mcu-battery.md
@@ -8,9 +8,7 @@ To enable this feature, check the **MCU Battery** option under **Enabled Feature
 
 - **Option key**: `mcu_battery`
 
-> **Note**: Disabling this feature removes all battery sensors from the registry.
-
----
+> Disabling this feature removes all battery sensors from the registry.
 
 ## Exposed Entities
 
@@ -28,26 +26,35 @@ To enable this feature, check the **MCU Battery** option under **Enabled Feature
 | --- | --- | --- |
 | **Battery abnormal** | Diagnostic binary sensor — `True` when the MCU reports an abnormal status flag. | `system/get_status` MCU data |
 
----
-
 ## Actions (Services)
 
 The following services are registered under the `glinet_router` domain when the MCU Battery feature is enabled:
 
 ### `get_mcu_battery_config`
+
 Retrieves the current battery warning configuration from the router. Supports response data.
 
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 **Response**: Returns current warning thresholds for `capacity`, `temp_high`, and `temp_low`, including whether each is enabled.
 
 ### `set_mcu_battery_config`
+
 Sets the battery warning configuration parameters.
 
-- **`capacity_enabled`**: Toggles low-capacity warnings.
-- **`capacity`**: Low-capacity warning percentage threshold.
-- **`temp_high_enabled`**: Toggles high-temperature warnings.
-- **`temp_high`**: High-temperature warning threshold in Celsius.
-- **`temp_low_enabled`**: Toggles low-temperature warnings.
-- **`temp_low`**: Low-temperature warning threshold in Celsius.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `capacity_enabled` | boolean | Yes | Toggles low-capacity warnings. |
+| `capacity` | integer (1-100) | Yes | Low-capacity warning percentage threshold. |
+| `temp_high_enabled` | boolean | Yes | Toggles high-temperature warnings. |
+| `temp_high` | integer | Yes | High-temperature warning threshold in Celsius. |
+| `temp_low_enabled` | boolean | Yes | Toggles low-temperature warnings. |
+| `temp_low` | integer | Yes | Low-temperature warning threshold in Celsius. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/mcu-oled.md
+++ b/docs/mcu-oled.md
@@ -8,30 +8,39 @@ To enable this feature, check the **MCU OLED** option under **Enabled Features**
 
 - **Option key**: `mcu_oled`
 
-> **Note**: Disabling this feature removes all MCU OLED actions.
-
----
+> Disabling this feature removes all MCU OLED actions.
 
 ## Actions (Services)
 
 The following services are registered under the `glinet_router` domain when the MCU OLED feature is enabled:
 
 ### `get_mcu_oled_config`
+
 Retrieves the current OLED screen display configuration from the router. Supports response data.
 
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 **Response**: Returns the current `screen_display` configuration flags.
 
 ### `set_mcu_oled_config`
+
 Updates sections displayed on the MCU OLED screen. Omitted fields retain their current router values.
 
-- **`main`** (Optional): Toggle showing the main screen.
-- **`wifi_password`** (Optional): Toggle showing the WiFi password.
-- **`wifi_2g`** (Optional): Toggle showing 2.4 GHz WiFi status.
-- **`wifi_5g`** (Optional): Toggle showing 5 GHz WiFi status.
-- **`lan`** (Optional): Toggle showing LAN network status.
-- **`vpn`** (Optional): Toggle showing VPN connection status.
-- **`custom`** (Optional): Toggle showing custom display content.
-- **`content`** (Optional): Custom display content or command string.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `main` | boolean | No | Toggle showing the main screen. |
+| `wifi_password` | boolean | No | Toggle showing the WiFi password. |
+| `wifi_2g` | boolean | No | Toggle showing 2.4 GHz WiFi status. |
+| `wifi_5g` | boolean | No | Toggle showing 5 GHz WiFi status. |
+| `lan` | boolean | No | Toggle showing LAN network status. |
+| `vpn` | boolean | No | Toggle showing VPN connection status. |
+| `custom` | boolean | No | Toggle showing custom display content. |
+| `content` | string | No | Custom display content or command string. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/modem-api.md
+++ b/docs/modem-api.md
@@ -34,11 +34,102 @@ newer from `system/get_info` and normalizes the new responses back into the exis
 
 | API | Purpose |
 | --- | --- |
-| `modem/get_modem_current_interface` | Discovers active modem interface names. The integration maps names such as `modem_1_1_s1` to `bus: "1-1", slot: 1`. |
-| `modem/get_network_status` | Reads per-slot dial status, ICCID, protocol, and traffic counters. |
-| `modem/get_network_info` | Reads per-slot IP address data, network interface, and cell information. |
-| `modem/get_signals` | Reads per-slot signal values such as RSRP, RSRQ, SINR, strength, and network type. |
+| `modem/get_modem_current_interface` | Discovers active modem interface names. The integration maps names such as `modem_0001_s1` to `bus: "0001", slot: 1`. On the user's 4.9 router the response carries one entry per active SIM slot (e.g. `modem_0001_s1`, `modem_0001_s2`). |
+| `modem/get_signals` | Reads per-slot signal values such as RSRP, RSRQ, SINR, strength, and network type. The integration issues one bodyless call per refresh and indexes the response by slot. |
+| `modem/get_network_status` (bodyless) | Reads per-slot dial status, ICCID, protocol, and traffic counters. The 4.9 firmware exposes this as a **bodyless** call — the response carries a `networks` array with one entry per active slot. |
+| `modem/get_network_info` (bodyless) | Reads per-slot IP address data (IPv4/IPv6 lease, gateway, DNS), network interface name, and cell information (band, mode, RSRP, RSRQ, SINR). The 4.9 firmware exposes this as a **bodyless** call — the response carries a `networks` array with one entry per active slot. |
+| `modem/get_sim_config` | Reads the per-SIM APN and configuration. The 4.9 firmware exposes this as a **per-bus** call — the integration issues one call per distinct modem bus and merges the ICCID-keyed APN onto each modem's `simcard` record. |
 | `modem/get_sms_list` | Lists SMS messages. On 4.9+ the integration calls this once per discovered bus. |
+
+#### Bodyless request shape (4.9+)
+
+The 4.9 bodyless calls have **empty params** and return every active network in a
+single response. Example for `modem/get_network_info`:
+
+```json
+{
+  "method": "call",
+  "jsonrpc": "2.0",
+  "params": ["<sid>", "modem", "get_network_info", {}],
+  "id": 0
+}
+```
+
+Response:
+
+```json
+{
+  "result": {
+    "ret": 0,
+    "resp": "Success",
+    "networks": [
+      {
+        "network_interface": "modem_0001_s1",
+        "bus": "0001:01:00.0",
+        "slot": "1",
+        "ipv4": {
+          "ip": "10.77.58.41",
+          "gateway": "10.77.58.42",
+          "netmask": "255.255.255.252",
+          "dns": ["188.31.250.128", "188.31.250.129"]
+        },
+        "cell_info": {
+          "mode": "NR5G-NSA",
+          "band": 78,
+          "rsrp": "-86",
+          "rsrq": "-10",
+          "sinr": "22"
+        }
+      }
+    ]
+  }
+}
+```
+
+The integration indexes the bodyless response by `(bus, slot)` and tries every bus
+alias for each target so the short logical bus (`0001`) and the full PCI bus
+(`0001:01:00.0`) both resolve to the same modem record. If the bodyless response
+returns no entries for a given target, the integration falls back to the per-target
+request shape (`{"bus": ..., "slot": ...}`) so older 4.9 builds that haven't
+flipped the endpoint still work.
+
+#### Per-bus SIM config (4.9+)
+
+The 4.9 firmware exposes the APN through a separate per-bus call:
+
+```json
+{
+  "method": "call",
+  "jsonrpc": "2.0",
+  "params": ["<sid>", "modem", "get_sim_config", {"bus": "0001:01:00.0"}],
+  "id": 0
+}
+```
+
+Response:
+
+```json
+{
+  "result": {
+    "8944200204977051694F": {
+      "manual": true,
+      "username": "",
+      "pincode": "",
+      "ip_type": 1,
+      "cid": 1,
+      "roaming": false,
+      "apn": "mob.asm.net",
+      "password": "",
+      "auth": "NONE"
+    }
+  }
+}
+```
+
+The response is keyed by ICCID. The integration picks the record whose ICCID matches
+the modem's ICCID (falling back to the first record) and copies the `apn` (plus
+other SIM fields when present) onto the modem's `simcard` so the `Cellular APN`
+sensor continues to resolve the value.
 
 ## Write APIs Used
 
@@ -48,17 +139,6 @@ newer from `system/get_info` and normalizes the new responses back into the exis
 | `modem/remove_sms` | Deletes SMS. The integration uses `scope: 10` with the message `name` for a single-message delete and includes `slot` on 4.9+ when known. |
 
 ## SMS Error Codes
-
-`modem/send_sms` may return:
-
-- `-1`: Cellular modem was not found
-- `-2`: Unknown error
-- `-3`: Sending failed
-- `-4`: Sending timeout
-- `-5`: Cellular modem does not support SMS
-- `-6`: Current network environment does not support SMS
-
-## Bus And Slot Selection
 
 Most modem APIs require `bus`; firmware 4.9+ may also require `slot`. The integration
 selects a default modem by:

--- a/docs/modem-api.md
+++ b/docs/modem-api.md
@@ -84,3 +84,8 @@ exposes `default_bus` for compatibility and also includes `default_slot` when av
 ## APIs Not Exposed
 
 The modem PDF also documents mutating APIs for reconnecting, auto-connect, SIM config, tower locking, traffic limits, firmware upgrade, and SIM unlock. Those are not exposed yet because they can disrupt router connectivity or require more UI/confirmation work.
+
+## Related Pages
+
+- [Cellular](cellular.md) — Cellular feature user reference.
+- [Router API Notes](router-api.md) — Endpoints, authentication, and module inventory.

--- a/docs/mwan3.md
+++ b/docs/mwan3.md
@@ -1,0 +1,52 @@
+# MWAN3 (Optional Feature)
+
+The **MWAN3** feature reads and updates the standard OpenWrt MWAN3 multi-WAN configuration through services. Use this when your router is configured with the upstream MWAN3 package rather than the GL.iNet-native KMWAN.
+
+## Setup Configuration
+
+To enable this feature, check the **MWAN3** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `mwan3`
+
+## Actions (Services)
+
+The following services are registered under the `glinet_router` domain when the MWAN3 feature is enabled:
+
+### `mwan3_get_config`
+
+Retrieves the current MWAN3 configuration from the router. Supports response data.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `mwan3_get_status`
+
+Retrieves the current MWAN3 interface status. Supports response data.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `mwan3_set_config`
+
+Updates the MWAN3 configuration.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `config` | object | Yes | New MWAN3 configuration. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `mwan3_set_interface`
+
+Updates a single MWAN3 interface.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `interface` | object | Yes | Interface definition to update. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [KMWAN](kmwan.md) — GL.iNet's preferred multi-WAN policy engine.
+- [Router API Notes](router-api.md) — Endpoints, authentication, and module inventory.

--- a/docs/openvpn-client.md
+++ b/docs/openvpn-client.md
@@ -10,13 +10,36 @@ To enable this feature, check the **OpenVPN Client** option under **Enabled Feat
 
 ## Exposed Entities
 
-### Switches
+The integration adapts to the router's firmware. On older firmware you get one switch per configured OpenVPN client; on 4.9 and newer you get one switch per dashboard tunnel.
+
+### Firmware 4.8 and older
 
 | Entity | Description | API Source |
 | --- | --- | --- |
-| **OpenVPN client switches** | One switch per configured OpenVPN client profile returned by the router. Toggles the specific client connection on or off. | `ovpn-client` API |
+| **OpenVPN client switches** | One switch per configured OpenVPN client profile returned by the router. Toggles the specific client connection on or off. | `ovpn-client` API. |
 
 The active client profile and its location are stored on the router but are not exposed as Home Assistant entities. They can be read directly from the router's web UI.
+
+### Firmware 4.9 and newer (VPN Dashboard)
+
+Firmware 4.9 introduces a unified **VPN dashboard**. The integration only sees the OpenVPN profiles that the router exposes on this dashboard — so **a new OpenVPN client has to be added to the VPN Dashboard before it appears in Home Assistant**. Once it is on the dashboard the integration queries `vpn-client.get_tunnel` and surfaces one switch per dashboard tunnel whose `via.type` is `openvpn`.
+
+> **Adding OpenVPN profiles on 4.9+**:
+> 1. Create / import the OpenVPN client in the router's admin UI as usual.
+> 2. Open the **VPN Dashboard** section of the admin UI and **preconfigure** the client onto a dashboard tunnel (assign it explicitly to a tunnel slot).
+> 3. Reload the integration in Home Assistant. The new tunnel switch will appear under the **OpenVPN Client** device.
+>
+> Do **not** simply toggle the client on through the dashboard to "register" it. Toggling a tunnel that has no profile preconfigured overwrites the slot and leaves the existing configuration empty, which causes the integration to lose that tunnel. Always assign the client to a tunnel slot before you toggle anything.
+
+> **Removing OpenVPN profiles on 4.9+**: if you remove (or unassign) an OpenVPN client from the VPN Dashboard on the router, the corresponding switch in Home Assistant is automatically removed on the next coordinator refresh. The dashboard should always reflect exactly what is currently configured on the router.
+
+> **No profiles configured on the dashboard**: if you have not pre-configured any OpenVPN profiles on the VPN dashboard, the router's firmware falls back to whatever tunnel was used last (or to the "default" / `novpn` tunnel) when a toggle is sent. The integration sends `vpn-client.set_tunnel` for the requested `tunnel_id`, but with no preconfigured profile the router will start whichever tunnel it currently considers the default. To get predictable, per-profile switches, preconfigure the OpenVPN clients on the VPN dashboard first.
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **OpenVPN Tunnel &lt;name&gt;** | One switch per dashboard tunnel. Reports the live link state from `vpn-client.get_status` and toggles the tunnel via `vpn-client.set_tunnel`. | `vpn-client` API (`get_tunnel`, `set_tunnel`, `get_status`). |
+
+> **Backwards compatibility**: 4.8 routers keep the per-profile switches — the dashboard path activates only when the firmware reports version 4.9 or newer. Switching between firmware versions (downgrade or upgrade) may require reloading the integration so the entity registry picks the correct representation.
 
 ## Related Pages
 

--- a/docs/openvpn-client.md
+++ b/docs/openvpn-client.md
@@ -1,6 +1,6 @@
 # OpenVPN Client (Optional Feature)
 
-The **OpenVPN Client** feature allows you to select the server location/profile and toggle configured OpenVPN client connections on your GL.iNet router.
+The **OpenVPN Client** feature surfaces every configured OpenVPN client profile on your GL.iNet router as a switch so you can turn individual tunnels on or off.
 
 ## Setup Configuration
 
@@ -8,18 +8,17 @@ To enable this feature, check the **OpenVPN Client** option under **Enabled Feat
 
 - **Option key**: `ovpn_client`
 
----
-
 ## Exposed Entities
-
-### Selects
-
-| Entity | Description | API Source |
-| --- | --- | --- |
-| **OpenVPN location** | Choose the server location configuration for the active OpenVPN client profile. | `ovpn-client/get_config` |
 
 ### Switches
 
 | Entity | Description | API Source |
 | --- | --- | --- |
 | **OpenVPN client switches** | One switch per configured OpenVPN client profile returned by the router. Toggles the specific client connection on or off. | `ovpn-client` API |
+
+The active client profile and its location are stored on the router but are not exposed as Home Assistant entities. They can be read directly from the router's web UI.
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/openvpn-server.md
+++ b/docs/openvpn-server.md
@@ -23,3 +23,8 @@ To enable this feature, check the **OpenVPN Server** option under **Enabled Feat
 | Entity | Description | API Source |
 | --- | --- | --- |
 | **OpenVPN Server** | Toggles the OpenVPN server on or off. | `ovpn-server` API |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/parental-control-feature.md
+++ b/docs/parental-control-feature.md
@@ -1,0 +1,76 @@
+# Parental Control (Optional Feature)
+
+The **Parental Control** feature exposes the GL.iNet router's parental control system to Home Assistant: group switches, per-client group assignment, the router's filtering mode, temporary overrides, and signature database updates.
+
+## Setup Configuration
+
+To enable this feature, check the **Parental & Access Control** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `parental_control`
+
+## Binary Sensors
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **Parental control group override** | One diagnostic binary sensor per parental group. `True` when a temporary override is currently active for that group. | `parental-control/get_status` |
+
+## Selects
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **Parental control group** | One select per tracked client device. Allows assigning the client to a parental group/profile, or `None` to remove group membership. Attached to the client MAC device. | `parental-control/get_config` |
+
+## Switches
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **Parental control** | Global switch to enable or disable all parental control features on the router. | `parental-control/set_config` |
+| **Parental control group** | One switch per parental control group. Enables or disables internet access limits for that group. | `parental-control/set_group` |
+
+## Actions (Services)
+
+The following services are registered under the `glinet_router` domain when the Parental & Access Control feature is enabled:
+
+### `parental_control_set_temporary_override`
+
+Enables or disables a temporary parental control override for a specific group.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `group_id` | string | Yes | Parental group ID (e.g., `group7342748`). |
+| `enabled` | boolean | Yes | Whether to enable the override. |
+| `rule_id` | string | Yes | Rule to apply (e.g., `drop`). |
+| `duration` | string | No | Duration string (e.g., `01:00:00`). |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `parental_control_set_filtering_mode`
+
+Sets the router's parental control filtering mode.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mode` | integer | Yes | Numeric filtering mode value. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `parental_control_update_signatures`
+
+Triggers a parental control signature database update on the router.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+### `parental_control_set_group_schedules`
+
+Enables or bypasses configured schedules for a parental control group.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `group_id` | string | Yes | Router parental group ID. |
+| `enabled` | boolean | Yes | Whether schedules should be enforced. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Access Control](access-control.md) — Blacklist/whitelist internet access control per device.
+- [Parental & Access Control parent page](parental-control.md)

--- a/docs/parental-control.md
+++ b/docs/parental-control.md
@@ -1,6 +1,6 @@
 # Parental & Access Control (Optional Feature)
 
-The **Parental & Access Control** feature enables per-client internet access switches, parental group assignment, router-level parental controls, temporary overrides, and signature database updates.
+The **Parental & Access Control** feature groups together the GL.iNet router's parental control system and per-client access control (blacklist/whitelist) into a single optional module. Each sub-feature is documented on its own page.
 
 ## Setup Configuration
 
@@ -8,72 +8,9 @@ To enable this feature, check the **Parental & Access Control** option under **E
 
 - **Option key**: `parental_control`
 
----
+## Sub-Features
 
-## Exposed Entities
-
-### Binary Sensors
-
-| Entity | Description | API Source |
-| --- | --- | --- |
-| **Parental control group override** | One diagnostic binary sensor per parental group. `True` when a temporary brief/override is currently active for that group. | `parental-control/get_status` |
-
-### Selects
-
-| Entity | Description | API Source |
-| --- | --- | --- |
-| **Parental control group** | One select per tracked client device. Allows assigning the client to a parental group/profile, or `None` to remove group membership. Attached to the client MAC device. | `parental-control/get_config` |
-
-### Switches
-
-| Entity | Description | API Source |
-| --- | --- | --- |
-| **Parental control** | Global switch to enable or disable all parental control features on the router. | `parental-control/set_config` |
-| **Parental control group** | One switch per parental control group. Enables or disables internet access limits for that group. | `parental-control/set_group` |
-| **Internet access** | One switch per tracked client device. Turning it off blocks that client's internet access; turning it on restores it. | `black_white_list/set_single_mac` |
-
----
-
-## Actions (Services)
-
-The following services are registered under the `glinet_router` domain when the Parental & Access Control feature is enabled:
-
-### `parental_control_set_temporary_override`
-Enables or disables a temporary parental control override for a specific group.
-
-- **`group_id`**: Parental group ID (e.g., `group7342748`).
-- **`enabled`**: Whether to enable the override.
-- **`rule_id`**: Rule to apply (e.g., `drop`).
-- **`duration`** (Optional): Duration string (e.g., `01:00:00`).
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `parental_control_set_filtering_mode`
-Sets the router's parental control filtering mode.
-
-- **`mode`**: Numeric filtering mode value.
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `parental_control_update_signatures`
-Triggers a parental control signature database update on the router.
-
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `access_control_set_mode`
-Switches device access control between blacklist and whitelist modes.
-
-- **`mode`**: `black` (blacklist) or `white` (whitelist).
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `access_control_set_device_block`
-Blocks or unblocks a specific client device by MAC address.
-
-- **`src_mac`**: Client MAC address.
-- **`block`**: Whether internet access should be blocked.
-- **`mac`** (Optional): Target a specific router by MAC address.
-
-### `parental_control_set_group_schedules`
-Enables or bypasses configured schedules for a parental control group.
-
-- **`group_id`**: Router parental group ID.
-- **`enabled`**: Whether schedules should be enforced.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Page | Description |
+| --- | --- |
+| [Parental Control](parental-control-feature.md) | Group switches, filtering mode, temporary overrides, and signature updates. |
+| [Access Control](access-control.md) | Per-client internet access switches, blacklist/whitelist mode, and device blocking. |

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -171,3 +171,9 @@ data:
   "hash-method": "sha256"
 }
 ```
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Targeting a Specific Router](router-targeting.md) — The optional `mac` parameter.
+- [Router API Notes](router-api.md) — Endpoints, authentication, and module inventory.

--- a/docs/port-forwards.md
+++ b/docs/port-forwards.md
@@ -1,0 +1,68 @@
+# Port Forwards (Optional Feature)
+
+The **Port Forwards** feature lets you add and remove port forwarding rules on your GL.iNet router. Forwarded ports route external traffic from the WAN to a specific internal host and port.
+
+## Setup Configuration
+
+To enable this feature, check the **Firewall** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `firewall`
+
+> Disabling this feature also removes the `Port forwards` sensor and the related firewall rule entities.
+
+## Sensors
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **Port forwards** | Count of active port forwarding rules. | `firewall/get_port_forwards` |
+
+## Actions (Services)
+
+The following services are registered under the `glinet_router` domain when the Firewall feature is enabled:
+
+### `add_port_forward`
+
+Adds a port forwarding rule.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | Yes | Descriptive name. |
+| `src` | string | Yes | Source zone (usually `wan`). |
+| `src_dport` | string | Yes | External port. |
+| `proto` | string | Yes | Protocol (`tcp`, `udp`, `tcpudp`). |
+| `dest` | string | Yes | Destination zone (usually `lan`). |
+| `dest_ip` | string | Yes | Internal IP address. |
+| `dest_port` | string | Yes | Internal port. |
+| `enabled` | boolean | No | Whether the rule is active. Defaults to `true`. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+Example:
+
+```yaml
+action: glinet_router.add_port_forward
+data:
+  name: Web server
+  src: wan
+  src_dport: "8443"
+  proto: tcp
+  dest: lan
+  dest_ip: 192.168.8.50
+  dest_port: "443"
+```
+
+### `remove_port_forward`
+
+Removes a port forwarding rule. If `remove_all` is `true`, all port forwarding rules are removed and `rule_id` is ignored.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `rule_id` | string | No | The ID of the rule to remove. |
+| `remove_all` | boolean | No | If `true`, removes all port forwarding rules. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Firewall Rules](firewall-rules.md) — Add and remove custom firewall rules.
+- [DMZ](dmz.md) — Toggle the DMZ feature.
+- [WAN Access](wan-access.md) — Toggle WAN ping, HTTPS, and SSH access.
+- [Firewall parent page](firewall.md)

--- a/docs/refresh-clients.md
+++ b/docs/refresh-clients.md
@@ -1,0 +1,34 @@
+# Refresh Clients (Service)
+
+The `refresh_clients` service forces the hub to immediately re-fetch the connected client list and request a coordinator refresh. This updates all dependent entities (device trackers, connected client counts, bandwidth sensors, etc.) without waiting for the next polling cycle.
+
+## Setup Configuration
+
+The `refresh_clients` service is always available regardless of optional feature selection.
+
+## Actions (Services)
+
+### `refresh_clients`
+
+Forces the hub to immediately re-fetch the connected client list and request a coordinator refresh.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+Example:
+
+```yaml
+action: glinet_router.refresh_clients
+```
+
+## When to Use
+
+- Right after adding or removing a client on the LAN.
+- When Home Assistant device tracker states appear stale.
+- After a router reboot to align the state with the current client list.
+
+## Related Pages
+
+- [Targeting a Specific Router](router-targeting.md)
+- [Services & Actions parent page](services.md)

--- a/docs/repeater.md
+++ b/docs/repeater.md
@@ -8,8 +8,6 @@ To enable this feature, check the **Repeater** option under **Enabled Features**
 
 - **Option key**: `repeater`
 
----
-
 ## Exposed Entities
 
 ### Sensors
@@ -49,30 +47,34 @@ The **Repeater state** sensor remains available whenever the repeater feature is
 | **Repeater bare mode** | Toggle bare mode for the active repeater connection. | `repeater/enter_bare_mode` / `repeater/exit_bare_mode` |
 | **Repeater smart reconnect** | Toggle smart reconnection logic. | `repeater/set_config` |
 
----
-
 ## Actions (Services)
 
 The following services are registered under the `glinet_router` domain when the Repeater feature is enabled:
 
 ### `scan_wifi`
+
 Scans available WiFi networks for repeater mode.
 
-- **`mac`** (Optional): Target a specific router by MAC address.
-- **`refresh`** (Optional): Force a fresh scan on the router instead of returning cached results.
-- **`all_band`** (Optional): Compatibility alias that requests a fresh router scan.
-- **`dfs`** (Optional): Compatibility alias that requests a fresh router scan.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+| `refresh` | boolean | No | Force a fresh scan on the router instead of returning cached results. |
+| `all_band` | boolean | No | Compatibility alias that requests a fresh router scan. |
+| `dfs` | boolean | No | Compatibility alias that requests a fresh router scan. |
 
 **Response Format**: Returns a `networks` array containing `ssid`, `bssid`, `signal`, `band`, `channel`, `encryption` (description), and `saved` status.
 
 ### `connect_wifi`
+
 Connects the router to an open or secured external WiFi network.
 
-- **`ssid`**: SSID of the network to connect to.
-- **`password`** (Optional): Password for secured networks. Omit for open networks.
-- **`remember`** (Optional): Save credentials for auto-reconnect. Defaults to `true`.
-- **`bssid`** (Optional): Lock connection to a specific AP MAC address.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `ssid` | string | Yes | SSID of the network to connect to. |
+| `password` | string | No | Password for secured networks. Omit for open networks. |
+| `remember` | boolean | No | Save credentials for auto-reconnect. Defaults to `true`. |
+| `bssid` | string | No | Lock connection to a specific AP MAC address. |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 Example:
 
@@ -85,17 +87,31 @@ data:
 ```
 
 ### `disconnect_wifi`
+
 Disconnects the router from the current external WiFi repeater network.
 
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 ### `get_saved_networks`
+
 Retrieves saved repeater WiFi networks from the router.
 
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 ### `remove_saved_network`
+
 Removes a saved repeater WiFi network from the router.
 
-- **`ssid`**: The SSID of the saved network to remove.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `ssid` | string | Yes | The SSID of the saved network to remove. |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/router-api.md
+++ b/docs/router-api.md
@@ -48,40 +48,9 @@ sid, module-name, function-name, optional parameters
 - `adguardhome`: AdGuard Home config and state.
 - `firewall`: Firewall rules, port forwarding, and DMZ management.
 - `mcu`: Optional battery warning config and OLED screen display config. Battery live status is reported by `system/get_status` under `mcu`.
-- `parental-control`: Parental control config, status, group updates, filtering mode, brief/temporary overrides, and signature updates.
-- `black_white_list`: Access control blacklist/whitelist config and single-MAC updates.
-- `fan`: Optional fan status, speed, and threshold control.
-- `led`: System LED control.
-- `macclone`: MAC clone capabilities.
 
-## Firmware Variation
+## Related Pages
 
-The GL.iNet API surface is not identical across all devices. When adding new features, prefer optional API calls for model-specific modules and expose entities only when useful data is returned.
-
-- Modem status uses `modem/get_info` and `modem/get_status` on firmware 4.8.x. On
-  firmware 4.9+ the client uses the newer per-slot modem endpoints and normalizes
-  those responses for the existing cellular sensors.
-
-## Repeater Notes
-
-The repeater integration follows the SDK 4.0 repeater module endpoints:
-
-- `repeater/scan` uses the documented `refresh` parameter for forced scans.
-- `repeater/connect` supports secured networks by passing `key` only when an action password is provided. The default action path uses DHCP client mode with `manual: false`, `protocol: dhcp`, `disguise: false`, and `auto_portal: false`.
-- Saved-network action responses intentionally omit saved WiFi passwords even though the router can return them.
-
-## Error Handling
-
-The integration treats documented/core APIs and optional model-specific APIs differently.
-
-Core APIs:
-
-- Authentication errors raise Home Assistant auth failures.
-- Setup connection failures raise Home Assistant setup retry errors.
-- Polling timeouts and router error payloads are logged and leave the previous state in place until the router responds again.
-
-Optional APIs:
-
-- LED, cellular, SMS, AdGuard Home, firewall, MCU, parental/access control, and client cache clear calls are optional.
-- Unsupported optional APIs are logged at debug level and do not fail setup.
-- Entities for optional features are created only when useful data is available or the feature is enabled in options.
+- [KMWAN](kmwan.md) — KMWAN multi-WAN services.
+- [MWAN3](mwan3.md) — MWAN3 multi-WAN services.
+- [Modem API Coverage](modem-api.md) — Cellular modem API.

--- a/docs/router-targeting.md
+++ b/docs/router-targeting.md
@@ -1,0 +1,24 @@
+# Targeting a Specific Router
+
+All `glinet_router` services accept an optional `mac` parameter. When multiple GL.iNet routers are configured in Home Assistant, you can use the router's MAC address to target a specific instance. If omitted, the first available hub is used.
+
+## Usage
+
+```yaml
+action: glinet_router.send_sms
+data:
+  mac: 94:83:C4:00:11:22
+  recipient: "+15551234567"
+  text: "Hello from Home Assistant"
+```
+
+## Notes
+
+- The MAC address must match the value reported by the integration for that router (visible in the integration device's **Settings**).
+- If only one router is configured, the `mac` parameter can be omitted.
+- Unknown or mismatched MAC addresses result in a Home Assistant service error.
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Refresh Clients](refresh-clients.md) — The `refresh_clients` service.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,4 +1,4 @@
-# Services & Actions (`services.py`)
+# Services & Actions
 
 The integration registers services under the `glinet_router` domain to allow manual interaction with the router from Home Assistant automations and scripts.
 
@@ -8,53 +8,30 @@ For full parameter details, visit the optional feature page for each service gro
 
 | Service Group | Feature Page |
 | --- | --- |
-| `send_sms`, `get_sms`, `remove_sms`, `refresh_sms` | [SMS](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/sms) |
-| `scan_wifi`, `connect_wifi`, `disconnect_wifi`, `get_saved_networks`, `remove_saved_network` | [Repeater](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/repeater) |
-| `add_firewall_rule`, `remove_firewall_rule`, `get_firewall_rules`, `add_port_forward`, `remove_port_forward`, `set_dmz` | [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) |
-| `get_mcu_battery_config`, `set_mcu_battery_config` | [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) |
-| `get_mcu_oled_config`, `set_mcu_oled_config` | [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) |
-| `kmwan_get_config`, `kmwan_get_status`, `kmwan_set_config`, `kmwan_set_interface`, `kmwan_set_sensitivity` | [KMWAN](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) |
-| `mwan3_get_config`, `mwan3_get_status`, `mwan3_set_config`, `mwan3_set_interface` | [MWAN3](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) |
-| `parental_control_set_temporary_override`, `parental_control_set_filtering_mode`, `parental_control_update_signatures`, `access_control_set_mode`, `access_control_set_device_block`, `parental_control_set_group_schedules` | [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) |
-| `playground` | [API Playground](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground) |
+| `send_sms`, `get_sms`, `remove_sms`, `refresh_sms` | [SMS](sms.md) |
+| `scan_wifi`, `connect_wifi`, `disconnect_wifi`, `get_saved_networks`, `remove_saved_network` | [Repeater](repeater.md) |
+| `add_firewall_rule`, `remove_firewall_rule`, `get_firewall_rules` | [Firewall Rules](firewall-rules.md) |
+| `add_port_forward`, `remove_port_forward` | [Port Forwards](port-forwards.md) |
+| `set_dmz` | [DMZ](dmz.md) |
+| `get_mcu_battery_config`, `set_mcu_battery_config` | [MCU Battery](mcu-battery.md) |
+| `get_mcu_oled_config`, `set_mcu_oled_config` | [MCU OLED](mcu-oled.md) |
+| `kmwan_get_config`, `kmwan_get_status`, `kmwan_set_config`, `kmwan_set_interface`, `kmwan_set_sensitivity` | [KMWAN](kmwan.md) |
+| `mwan3_get_config`, `mwan3_get_status`, `mwan3_set_config`, `mwan3_set_interface` | [MWAN3](mwan3.md) |
+| `parental_control_set_temporary_override`, `parental_control_set_filtering_mode`, `parental_control_update_signatures`, `parental_control_set_group_schedules` | [Parental Control](parental-control-feature.md) |
+| `access_control_set_mode`, `access_control_set_device_block` | [Access Control](access-control.md) |
+| `playground` | [API Playground](playground.md) |
 
----
+## Core Services
 
-## API Playground
+These services are always available regardless of optional feature selection.
 
-### `playground`
-
-Sends a custom JSON-RPC or ubus request to the GL.iNet router and waits to return the raw JSON response. This service is only available if **API Playground** is enabled in the configuration flow options.
-
-For a full guide, request-routing rules, and multiple examples, see the dedicated [API Playground Documentation](playground.md) (or [Wiki page](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground)).
-
-- **`method`**: The RPC or ubus method. Use a slash to call ubus objects, e.g. `system/get_info`, or specify top-level RPC methods (like `challenge`).
-- **`body`** (Optional): A JSON/YAML dictionary containing parameters/arguments for the request.
-- **`mac`** (Optional): Target a specific router by MAC address.
-
----
-
-
-## Fan Control
-
-### `set_fan_temperature`
-
-Sets the temperature threshold at which the router's fan will start running. Available on routers with a controllable fan.
-
-- **`temperature`**: Target threshold temperature in Celsius (typically 70–90).
-- **`mac`** (Optional): Target a specific router by MAC address.
-
----
-
-## Targeting a Specific Router
-
-All services accept an optional **`mac`** parameter. When multiple GL.iNet routers are configured in Home Assistant, you can use the router's MAC address to target a specific instance. If omitted, the first available hub is used.
-
----
-
-## Internal Logic
-
-| Function | Purpose |
+| Service | Page |
 | --- | --- |
-| `async_register_services` | Entry point during integration setup to register all domain services. |
-| `_get_hub` | Helper to find the active `GLinetHub` instance matching the provided MAC address. |
+| `set_fan_temperature` | [Smart Fan](smart-fan.md) |
+| `refresh_clients` | [Refresh Clients](refresh-clients.md) |
+
+## Reference
+
+- [Targeting a Specific Router](router-targeting.md) — The optional `mac` parameter shared by every service.
+- [Triggers](triggers.md) — Building automations that react to GL.iNet router state.
+- [Conditions](conditions.md) — Using Home Assistant's built-in conditions on integration entities.

--- a/docs/services.md
+++ b/docs/services.md
@@ -8,15 +8,15 @@ For full parameter details, visit the optional feature page for each service gro
 
 | Service Group | Feature Page |
 | --- | --- |
-| `send_sms`, `get_sms`, `remove_sms`, `refresh_sms` | [SMS](https://github.com/vithurshanselvarajah/glinet-router/wiki/sms) |
-| `scan_wifi`, `connect_wifi`, `disconnect_wifi`, `get_saved_networks`, `remove_saved_network` | [Repeater](https://github.com/vithurshanselvarajah/glinet-router/wiki/repeater) |
-| `add_firewall_rule`, `remove_firewall_rule`, `get_firewall_rules`, `add_port_forward`, `remove_port_forward`, `set_dmz` | [Firewall](https://github.com/vithurshanselvarajah/glinet-router/wiki/firewall) |
-| `get_mcu_battery_config`, `set_mcu_battery_config` | [MCU Battery](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-battery) |
-| `get_mcu_oled_config`, `set_mcu_oled_config` | [MCU OLED](https://github.com/vithurshanselvarajah/glinet-router/wiki/mcu-oled) |
-| `kmwan_get_config`, `kmwan_get_status`, `kmwan_set_config`, `kmwan_set_interface`, `kmwan_set_sensitivity` | [KMWAN](https://github.com/vithurshanselvarajah/glinet-router/wiki/router-api) |
-| `mwan3_get_config`, `mwan3_get_status`, `mwan3_set_config`, `mwan3_set_interface` | [MWAN3](https://github.com/vithurshanselvarajah/glinet-router/wiki/router-api) |
-| `parental_control_set_temporary_override`, `parental_control_set_filtering_mode`, `parental_control_update_signatures`, `access_control_set_mode`, `access_control_set_device_block`, `parental_control_set_group_schedules` | [Parental & Access Control](https://github.com/vithurshanselvarajah/glinet-router/wiki/parental-control) |
-| `playground` | [API Playground](https://github.com/vithurshanselvarajah/glinet-router/wiki/playground) |
+| `send_sms`, `get_sms`, `remove_sms`, `refresh_sms` | [SMS](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/sms) |
+| `scan_wifi`, `connect_wifi`, `disconnect_wifi`, `get_saved_networks`, `remove_saved_network` | [Repeater](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/repeater) |
+| `add_firewall_rule`, `remove_firewall_rule`, `get_firewall_rules`, `add_port_forward`, `remove_port_forward`, `set_dmz` | [Firewall](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/firewall) |
+| `get_mcu_battery_config`, `set_mcu_battery_config` | [MCU Battery](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-battery) |
+| `get_mcu_oled_config`, `set_mcu_oled_config` | [MCU OLED](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/mcu-oled) |
+| `kmwan_get_config`, `kmwan_get_status`, `kmwan_set_config`, `kmwan_set_interface`, `kmwan_set_sensitivity` | [KMWAN](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) |
+| `mwan3_get_config`, `mwan3_get_status`, `mwan3_set_config`, `mwan3_set_interface` | [MWAN3](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-api) |
+| `parental_control_set_temporary_override`, `parental_control_set_filtering_mode`, `parental_control_update_signatures`, `access_control_set_mode`, `access_control_set_device_block`, `parental_control_set_group_schedules` | [Parental & Access Control](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/parental-control) |
+| `playground` | [API Playground](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground) |
 
 ---
 
@@ -26,7 +26,7 @@ For full parameter details, visit the optional feature page for each service gro
 
 Sends a custom JSON-RPC or ubus request to the GL.iNet router and waits to return the raw JSON response. This service is only available if **API Playground** is enabled in the configuration flow options.
 
-For a full guide, request-routing rules, and multiple examples, see the dedicated [API Playground Documentation](playground.md) (or [Wiki page](https://github.com/vithurshanselvarajah/glinet-router/wiki/playground)).
+For a full guide, request-routing rules, and multiple examples, see the dedicated [API Playground Documentation](playground.md) (or [Wiki page](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/playground)).
 
 - **`method`**: The RPC or ubus method. Use a slash to call ubus objects, e.g. `system/get_info`, or specify top-level RPC methods (like `challenge`).
 - **`body`** (Optional): A JSON/YAML dictionary containing parameters/arguments for the request.

--- a/docs/smart-fan.md
+++ b/docs/smart-fan.md
@@ -1,37 +1,43 @@
-# Smart Fan Controls
+# Smart Fan (Optional Feature)
 
-Some GL.iNet routers expose fan status and temperature settings through the device API. When that data is available, the integration surfaces it in Home Assistant.
+Some GL.iNet routers expose fan status and threshold settings through the device API. When that data is available, the integration surfaces it in Home Assistant.
 
-## What you get
+## Setup Configuration
 
-- A binary sensor showing whether the fan is currently running.
-- A sensor for the current fan speed in RPM.
-- A diagnostic sensor for the configured fan trigger temperature.
-- A number entity that lets you set the trigger temperature used by the router.
+The fan feature does not require a separate option to be enabled. It is available automatically when the router reports fan data through the API.
 
-## Setup
+## Exposed Entities
 
-No separate feature toggle is required for this support. It is available automatically when the router reports fan data.
+| Entity | Type | Description | API Source |
+| --- | --- | --- | --- |
+| **Fan status** | `binary_sensor` | Whether the fan is currently running. | `fan/get_status` |
+| **Fan speed** | `sensor` | Current fan speed in RPM. Includes `running` and `temperature_threshold` attributes when supported. | `fan/get_status` |
+| **Fan threshold temperature** | `sensor` | Configured temperature at which the fan starts, in °C (read-only display). | `fan/get_config` |
 
-## Configuration
+> The fan trigger temperature cannot be changed from a `number` entity. Use the `set_fan_temperature` service below to update the threshold.
 
-Use the fan trigger temperature number entity to adjust the threshold for the router's fan behavior. The integration also shows the current threshold and fan speed as attributes where supported.
+## Actions (Services)
 
-## Service
-
-The integration registers a service named `set_fan_temperature`.
+The following service is registered under the `glinet_router` domain:
 
 ### `set_fan_temperature`
 
-Sets the router fan threshold temperature.
+Sets the router's fan trigger temperature.
 
-- **`temperature`**: The new trigger temperature in Celsius.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `temperature` | integer (70-90) | Yes | New trigger temperature in Celsius. |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 Example:
 
 ```yaml
 action: glinet_router.set_fan_temperature
 data:
-  temperature: 70
+  temperature: 75
 ```
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/sms.md
+++ b/docs/sms.md
@@ -8,8 +8,6 @@ To enable this feature, check the **SMS** option under **Enabled Features** in t
 
 - **Option key**: `sms`
 
----
-
 ## Exposed Entities
 
 ### Sensors
@@ -29,38 +27,49 @@ The `messages` attribute contains objects with the following fields:
 | `text` | Message body. |
 | `timestamp` | Message timestamp (if available). |
 
----
-
 ## Actions (Services)
 
 The following services are registered under the `glinet_router` domain when the SMS feature is enabled:
 
 ### `send_sms`
+
 Sends a text message.
 
-- **`recipient`**: The destination phone number including country code.
-- **`text`**: The message body. Messages longer than 160 characters are automatically split and sent sequentially.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `recipient` | string | Yes | The destination phone number including country code. |
+| `text` | string | Yes | The message body. Messages longer than 160 characters are automatically split and sent sequentially. |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 ### `get_sms`
+
 Retrieves the list of SMS messages currently stored on the router. Supports response data.
 
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 **Response Format**: Returns a `messages` array (same structure as the sensor attributes above).
 
 ### `remove_sms`
+
 Deletes SMS messages from the router based on a scope or specific ID.
 
-- **`scope`**: The deletion scope:
-  - `10` — Specific single SMS (requires `message_id`).
-  - `11` — All SMS.
-  - `0` — All unread SMS.
-  - `1` — All read SMS.
-- **`message_id`** (Optional): The unique ID of the message to delete. Found in the `Unread messages` sensor attributes. Required if `scope` is `10`.
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `scope` | integer | Yes | The deletion scope: `10` — Specific single SMS (requires `message_id`). `11` — All SMS. `0` — All unread SMS. `1` — All read SMS. |
+| `message_id` | string | No | The unique ID of the message to delete. Found in the `Unread messages` sensor attributes. Required if `scope` is `10`. |
+| `mac` | string | No | Target a specific router by MAC address. |
 
 ### `refresh_sms`
+
 Manually triggers a poll for new SMS messages.
 
-- **`mac`** (Optional): Target a specific router by MAC address.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mac` | string | No | Target a specific router by MAC address. |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/system-sensors.md
+++ b/docs/system-sensors.md
@@ -1,0 +1,40 @@
+# System Sensors (Core)
+
+The integration exposes system status sensors that are always available regardless of optional feature selection.
+
+## Router Diagnostics
+
+| Entity | Source | Notes |
+| --- | --- | --- |
+| **CPU temperature** | `system/get_status` | Diagnostic sensor. Available when supported by the router. |
+| **Load avg (1m)** | `system/get_status` | Diagnostic sensor. |
+| **Load avg (5m)** | `system/get_status` | Diagnostic sensor. |
+| **Load avg (15m)** | `system/get_status` | Diagnostic sensor. |
+| **Memory usage** | `system/get_status` | Calculated from total/free memory. |
+| **Flash usage** | `system/get_status` | Calculated from total/free flash. |
+| **Uptime** | `system/get_status` | Timestamp sensor. |
+| **Fan speed** | `fan/get_status` | Diagnostic sensor showing current fan RPM. Available on routers with a fan. |
+| **Fan threshold temperature** | `fan/get_config` | Diagnostic sensor showing the current fan temperature threshold. Available on routers with a fan. |
+
+## Internet and Traffic
+
+| Entity | Source | Notes |
+| --- | --- | --- |
+| **WAN status (per interface)** | `edgerouter/get_status` | One sensor per detected WAN interface (e.g., Ethernet 1, Ethernet 2, Repeater, Cellular, Tethering). Reports `Up`, `Down`, or `Unknown`. Specific interfaces and protocols (IPv4/IPv6) can be configured via the **WAN Status Monitors** option in the options flow. |
+| **Connected clients** | `clients/get_online` | Count of currently online tracked clients. |
+
+## Client Bandwidth
+
+Each tracked client includes real-time diagnostic sensors attached to the client device:
+
+- **Download rate** — current download bandwidth.
+- **Upload rate** — current upload bandwidth.
+- **IP address** — current IP address of the client.
+
+These sensors are created only when the router reports bandwidth fields in the client list. Rates are calculated from delta changes between polls when explicit rate fields are missing.
+
+## Related Pages
+
+- [Entity Reference parent page](entities.md)
+- [Switches](core-switches.md) — WiFi and LED core switches.
+- [Binary Sensors](core-binary-sensors.md) — Fan status, repeater, and parental override sensors.

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -17,3 +17,8 @@ To enable this feature, check the **Tailscale** option under **Enabled Features*
 | Entity | Description | API Source |
 | --- | --- | --- |
 | **Tailscale** | Toggles the Tailscale service on or off. Only created when Tailscale is configured on the router. | `tailscale/get_status` / `tailscale/set_config` |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,0 +1,42 @@
+# Triggers
+
+This integration does **not** provide any custom trigger platform (e.g. integration-level event triggers or device automations of its own).
+
+You can still build automations that react to GL.iNet router state by using **state triggers** on the entities the integration exposes — for example, trigger when the `binary_sensor.repeater_connected` state changes, or when a `sensor.fan_speed` crosses a threshold. For a full list of entities, see the [Entity Reference](entities.md).
+
+A ready-made pattern is also available for SMS events using Home Assistant's built-in `time_pattern` trigger — see [Automation Templates → SMS Notification](automation-sms-notification.md).
+
+## Examples
+
+### State trigger on repeater connection
+
+```yaml
+trigger:
+  - platform: state
+    entity_id: binary_sensor.repeater_connected
+    to: "on"
+action:
+  - action: notify.mobile_app
+    data:
+      title: "Repeater connected"
+      message: "WiFi repeater is now online"
+```
+
+### Numeric state trigger on fan speed
+
+```yaml
+trigger:
+  - platform: numeric_state
+    entity_id: sensor.fan_speed
+    above: 4000
+action:
+  - action: logbook.log
+    data:
+      name: "Router fan"
+      message: "Fan speed exceeded 4000 RPM"
+```
+
+## Related Pages
+
+- [Conditions](conditions.md)
+- [Services & Actions parent page](services.md)

--- a/docs/unknown-devices.md
+++ b/docs/unknown-devices.md
@@ -27,3 +27,8 @@ When unknown device discovery is enabled, the integration evaluates each new dev
 ## Notes
 
 This feature is especially useful if you want Home Assistant to stay tidy and only track the devices you actually care about.
+
+## Related Pages
+
+- [Device Trackers](device-trackers.md) — Per-client device tracking.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/update-entity.md
+++ b/docs/update-entity.md
@@ -1,0 +1,17 @@
+# Firmware Update
+
+The integration exposes a native Home Assistant update entity that surfaces the router's current firmware version and online upgrade metadata.
+
+| Entity | Source | Notes |
+| --- | --- | --- |
+| **Firmware** | `upgrade/check_firmware_online`, `upgrade/get_config`, `upgrade/upgrade_online` | Native Home Assistant firmware update entity. Shows release notes when available and only exposes install when the router provides the required download metadata. |
+
+## Notes
+
+- Release notes are pulled from the router's online firmware metadata when available.
+- Install is only exposed when the router provides the required download metadata.
+
+## Related Pages
+
+- [Entity Reference parent page](entities.md)
+- [Buttons](buttons.md) — Reboot and fan test buttons.

--- a/docs/wan-access.md
+++ b/docs/wan-access.md
@@ -1,0 +1,26 @@
+# WAN Access (Optional Feature)
+
+The **WAN Access** feature exposes switches for the three remote-access settings the GL.iNet router firewall supports: ICMP echo responses, HTTPS management, and SSH management.
+
+## Setup Configuration
+
+To enable this feature, check the **Firewall** option under **Enabled Features** in the integration configuration or options flow.
+
+- **Option key**: `firewall`
+
+## Switches
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **WAN Ping Access** | Toggle whether the router responds to ICMP echo requests from the WAN. | `firewall/set_wan_access` |
+| **WAN HTTPS Access** | Toggle remote HTTPS management access from the WAN. | `firewall/set_wan_access` |
+| **WAN SSH Access** | Toggle remote SSH management access from the WAN. | `firewall/set_wan_access` |
+
+> WAN access switches are exposed only when the Firewall feature is enabled.
+
+## Related Pages
+
+- [Firewall Rules](firewall-rules.md) — Add and remove custom firewall rules.
+- [Port Forwards](port-forwards.md) — Add and remove port forwarding rules.
+- [DMZ](dmz.md) — Toggle the DMZ feature.
+- [Firewall parent page](firewall.md)

--- a/docs/wireguard-client.md
+++ b/docs/wireguard-client.md
@@ -12,13 +12,34 @@ To enable this feature, check the **WireGuard Client** option under **Enabled Fe
 
 ## Exposed Entities
 
-### Switches
+The integration adapts to the router's firmware. On older firmware you get one switch per configured WireGuard profile; on 4.9 and newer you get one switch per dashboard tunnel.
+
+### Firmware 4.8 and older
 
 | Entity | Description | API Source |
 | --- | --- | --- |
-| **WireGuard client switches** | One switch per configured WireGuard client profile returned by the router. Toggles the specific connection profile on or off. | `wg-client` or `vpn-client` API, depending on firmware version. |
+| **WireGuard client switches** | One switch per configured WireGuard client profile returned by the router. Toggles the specific connection profile on or off. | `wg-client` or legacy `vpn-client` API. |
 
-> **Note**: Newer GL.iNet firmware versions use the `vpn-client` API. Older firmware uses the `wg-client` API. The integration detects and uses the correct API automatically.
+### Firmware 4.9 and newer (VPN Dashboard)
+
+Firmware 4.9 introduces a unified **VPN dashboard**. The integration only sees the WireGuard profiles that the router exposes on this dashboard — so **a new WireGuard client has to be added to the VPN Dashboard before it appears in Home Assistant**. Once it is on the dashboard the integration queries `vpn-client.get_tunnel` and surfaces one switch per dashboard tunnel whose `via.type` is `wireguard`.
+
+> **Adding WireGuard profiles on 4.9+**:
+> 1. Create / import the WireGuard profile in the router's admin UI as usual.
+> 2. Open the **VPN Dashboard** section of the admin UI and **preconfigure** the profile onto a dashboard tunnel (assign it explicitly to a tunnel slot).
+> 3. Reload the integration in Home Assistant. The new tunnel switch will appear under the **WireGuard Client** device.
+>
+> Do **not** simply toggle the profile on through the dashboard to "register" it. Toggling a tunnel that has no profile preconfigured overwrites the slot and leaves the existing configuration empty, which causes the integration to lose that tunnel. Always assign the profile to a tunnel slot before you toggle anything.
+
+> **Removing WireGuard profiles on 4.9+**: if you remove (or unassign) a WireGuard profile from the VPN Dashboard on the router, the corresponding switch in Home Assistant is automatically removed on the next coordinator refresh. The dashboard should always reflect exactly what is currently configured on the router.
+
+> **No profiles configured on the dashboard**: if you have not pre-configured any WireGuard profiles on the VPN dashboard, the router's firmware falls back to whatever tunnel was used last (or to the "default" / `novpn` tunnel) when a toggle is sent. The integration sends `vpn-client.set_tunnel` for the requested `tunnel_id`, but with no preconfigured profile the router will start whichever tunnel it currently considers the default. To get predictable, per-profile switches, preconfigure the WireGuard profiles on the VPN dashboard first.
+
+| Entity | Description | API Source |
+| --- | --- | --- |
+| **WG Tunnel &lt;name&gt;** | One switch per dashboard tunnel. Reports the live link state from `vpn-client.get_status` and toggles the tunnel via `vpn-client.set_tunnel`. | `vpn-client` API (`get_tunnel`, `set_tunnel`, `get_status`). |
+
+> **Backwards compatibility**: 4.8 routers keep the per-profile switches — the dashboard path activates only when the firmware reports version 4.9 or newer. Switching between firmware versions (downgrade or upgrade) may require reloading the integration so the entity registry picks the correct representation.
 
 ## Related Pages
 

--- a/docs/wireguard-client.md
+++ b/docs/wireguard-client.md
@@ -19,3 +19,8 @@ To enable this feature, check the **WireGuard Client** option under **Enabled Fe
 | **WireGuard client switches** | One switch per configured WireGuard client profile returned by the router. Toggles the specific connection profile on or off. | `wg-client` or `vpn-client` API, depending on firmware version. |
 
 > **Note**: Newer GL.iNet firmware versions use the `vpn-client` API. Older firmware uses the `wg-client` API. The integration detects and uses the correct API automatically.
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/wireguard-server.md
+++ b/docs/wireguard-server.md
@@ -23,3 +23,8 @@ To enable this feature, check the **WireGuard Server** option under **Enabled Fe
 | Entity | Description | API Source |
 | --- | --- | --- |
 | **WG Server** | Toggles the WireGuard server on or off. | `wg-server/start` / `wg-server/stop` |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/docs/zerotier.md
+++ b/docs/zerotier.md
@@ -19,3 +19,8 @@ To enable this feature, check the **ZeroTier** option under **Enabled Features**
 | Entity | Description | API Source |
 | --- | --- | --- |
 | **ZeroTier** | Toggles the ZeroTier service connection on or off. | `zerotier/get_status` / `zerotier/set_config` |
+
+## Related Pages
+
+- [Services & Actions](services.md) — How to use Home Assistant services with this integration.
+- [Entity Reference](entities.md) — All core and optional entities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,4 @@ select = ["E", "F", "I", "UP", "B", "BLE", "RUF"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "glinet-router"
-version = "1.6.0"
+version = "1.6.1"
 description = "Unified GL.iNet Router Home Assistant integration with bundled API client"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,21 @@ version = "1.6.0"
 description = "Unified GL.iNet Router Home Assistant integration with bundled API client"
 readme = "README.md"
 requires-python = ">=3.14"
+license = "MIT"
 authors = [
     { name = "Vithurshan Selvarajah" },
 ]
 dependencies = [
     "homeassistant>=2026.5.0",
     "passlib>=1.7.4",
-    "pytest>=9.0.3",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-homeassistant-custom-component>=0.13.0",
+    "aioresponses>=0.7.7",
 ]
 
 [tool.ruff]
@@ -27,3 +35,4 @@ select = ["E", "F", "I", "UP", "B", "BLE", "RUF"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,9 +287,6 @@ def pytest_pyfunc_call(pyfuncitem: Any) -> bool:
     if not inspect.iscoroutinefunction(testfunction):
         return False
 
-    kwargs = {
-        name: pyfuncitem.funcargs[name]
-        for name in pyfuncitem._fixtureinfo.argnames
-    }
+    kwargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
     asyncio.run(testfunction(**kwargs))
     return True

--- a/tests/test_adguard.py
+++ b/tests/test_adguard.py
@@ -8,12 +8,12 @@ async def test_fetch_adguard_status() -> None:
     hub = GLinetHub.__new__(GLinetHub)
     hub._api = MagicMock()
     hub._adguard_status = None
-    
+
     mock_config = {"enabled": True, "dns_enabled": False}
     hub._invoke_optional_api = AsyncMock(return_value=mock_config)
-    
+
     await hub.fetch_adguard_status()
-    
+
     assert hub.adguard_status.enabled is True
     assert hub.adguard_status.dns_enabled is False
 
@@ -23,11 +23,11 @@ async def test_set_adguard_enabled() -> None:
     hub._api = MagicMock()
     hub._api.adguard.set_config = AsyncMock()
     hub._adguard_status = AdGuardStatus(enabled=False, dns_enabled=True)
-    
+
     hub._invoke_api = AsyncMock()
     hub.fetch_adguard_status = AsyncMock()
-    
+
     await hub.set_adguard_enabled(True)
-    
+
     hub._invoke_api.assert_called_once()
     # To test the lambda, we'd need more complex mocking, but this is a start

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -250,6 +250,7 @@ async def test_sms_methods_use_sms_module_payloads() -> None:
         ]
     )
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
+    client._firmware_version = (4, 7, 0, 0)
 
     assert await client.modem.get_sms_list() == [{"name": "sms-1", "body": "hello"}]
     assert await client.modem.send_sms("1-1", "+441234567890", "hi") == {"sent": True}
@@ -293,6 +294,7 @@ async def test_send_sms_includes_slot_when_supplied() -> None:
 async def test_get_modem_info_uses_documented_modem_endpoint() -> None:
     session = FakeSession([{"result": {"modems": [{"bus": "1-1"}]}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
+    client._firmware_version = (4, 7, 0, 0)
 
     assert await client.modem.get_info() == {"modems": [{"bus": "1-1"}]}
     assert session.requests[0]["json"]["params"] == ["sid-1", "modem", "get_info", {}]
@@ -576,6 +578,7 @@ async def test_get_modem_info_extracts_nested_fields() -> None:
         ]
     )
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
+    client._firmware_version = (4, 7, 0, 0)
 
     info = await client.modem.get_modem_info()
     assert len(info) == 1
@@ -586,19 +589,19 @@ async def test_get_modem_info_extracts_nested_fields() -> None:
     assert info[0].apn == "test.apn"
 
 
-async def test_wireguard_state_uses_new_vpn_client_module_for_new_firmware() -> None:
+async def test_wireguard_state_uses_vpn_client_module_for_4_9() -> None:
     session = FakeSession([{"result": {"status_list": [{"type": "wireguard", "peer_id": 7}]}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    client._firmware_version = (4, 8, 0, 0)
+    client._firmware_version = (4, 9, 0, 0)
 
     assert await client.wg_client.get_wireguard_state() == [{"type": "wireguard", "peer_id": 7}]
     assert session.requests[0]["json"]["params"] == ["sid-1", "vpn-client", "get_status", {}]
 
 
-async def test_wireguard_state_uses_legacy_module_for_old_firmware() -> None:
+async def test_wireguard_state_uses_legacy_module_for_4_8() -> None:
     session = FakeSession([{"result": {"status": 1, "peer_id": 7}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    client._firmware_version = (4, 7, 9, 0)
+    client._firmware_version = (4, 8, 0, 0)
 
     assert await client.wg_client.get_wireguard_state() == [{"status": 1, "peer_id": 7}]
     assert session.requests[0]["json"]["params"] == ["sid-1", "wg-client", "get_status", {}]

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -61,6 +61,7 @@ class FakeSession:
             return FakePostContext(payload)
         return FakePostContext(FakeResponse(payload))
 
+
 @pytest.mark.parametrize(
     ("version", "expected"),
     [
@@ -179,17 +180,20 @@ async def test_repeater_scan_and_connect_use_documented_payloads() -> None:
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
 
     assert await client.repeater.scan({"refresh": True}) == [{"ssid": "SecuredNet"}]
-    assert await client.repeater.connect(
-        {
-            "ssid": "SecuredNet",
-            "key": "secret-pass",
-            "remember": True,
-            "manual": False,
-            "protocol": "dhcp",
-            "disguise": False,
-            "auto_portal": False,
-        }
-    ) == {}
+    assert (
+        await client.repeater.connect(
+            {
+                "ssid": "SecuredNet",
+                "key": "secret-pass",
+                "remember": True,
+                "manual": False,
+                "protocol": "dhcp",
+                "disguise": False,
+                "auto_portal": False,
+            }
+        )
+        == {}
+    )
 
     assert [request["json"]["params"] for request in session.requests] == [
         ["sid-1", "repeater", "scan", {"refresh": True}],
@@ -273,9 +277,7 @@ async def test_send_sms_includes_slot_when_supplied() -> None:
     session = FakeSession([{"result": {"sent": True}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
 
-    assert await client.modem.send_sms(
-        "cpu", "+441234567890", "hi", slot=2
-    ) == {"sent": True}
+    assert await client.modem.send_sms("cpu", "+441234567890", "hi", slot=2) == {"sent": True}
 
     assert session.requests[0]["json"]["params"] == [
         "sid-1",
@@ -415,15 +417,7 @@ async def test_modem_sms_list_uses_49_bus_payload_for_new_firmware() -> None:
 
 async def test_get_kmwan_status_uses_kmwan_endpoint() -> None:
     session = FakeSession(
-        [
-            {
-                "result": {
-                    "interfaces": [
-                        {"interface": "wan", "status_v4": 1, "status_v6": 0}
-                    ]
-                }
-            }
-        ]
+        [{"result": {"interfaces": [{"interface": "wan", "status_v4": 1, "status_v6": 0}]}}]
     )
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
 
@@ -641,4 +635,3 @@ async def test_custom_call_sends_expected_payloads() -> None:
             "id": 0,
         },
     ]
-

--- a/tests/test_client_sensor.py
+++ b/tests/test_client_sensor.py
@@ -13,19 +13,19 @@ def test_client_ip_sensor() -> None:
     hub = MagicMock()
     hub.router_id = "test_router"
     hub.tracked_devices = {}
-    
+
     device = ClientDeviceInfo("aa:bb:cc:dd:ee:ff", "Test Device")
     device.apply_update({"ip": "192.168.8.10", "online": True})
-    
+
     description = ClientSensorEntityDescription(
         key="ip_address",
         name="IP address",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda d: d.ip_address,
     )
-    
+
     sensor = ClientSensor(hub, device, description)
-    
+
     assert sensor.native_value == "192.168.8.10"
     assert sensor.entity_category == EntityCategory.DIAGNOSTIC
     assert sensor.name == "IP address"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,7 +12,9 @@ from custom_components.glinet_router.config_flow import (
     process_user_input,
 )
 from custom_components.glinet_router.const import (
+    CONF_PARALLEL_REQUESTS,
     CONF_WAN_STATUS_MONITORS,
+    DEFAULT_PARALLEL_REQUESTS,
     DEFAULT_USERNAME,
     FEATURE_KMWAN,
     FEATURE_MWAN3,
@@ -105,3 +107,65 @@ def test_wan_monitor_options_use_friendly_known_interface_names() -> None:
         {"label": "custom_wan IPv4", "value": "custom_wan:ipv4"},
         {"label": "custom_wan IPv6", "value": "custom_wan:ipv6"},
     ]
+
+
+def test_parallel_requests_default_is_false() -> None:
+    assert DEFAULT_PARALLEL_REQUESTS is False
+
+
+async def test_process_user_input_stores_parallel_requests(monkeypatch) -> None:
+
+    def fake_init(self, host: str, hass: Any) -> None:
+        self.host = host
+        self.username = DEFAULT_USERNAME
+        self.router_mac = "00:00:00:00:00:00"
+        self.router_model = "mr200"
+        self.wan_interfaces = ["wan"]
+
+    async def fake_check_reachable(self) -> bool:
+        return True
+
+    async def fake_attempt_login(self, password: str) -> bool:
+        return True
+
+    monkeypatch.setattr(SetupHub, "__init__", fake_init)
+    monkeypatch.setattr(SetupHub, "check_reachable", fake_check_reachable)
+    monkeypatch.setattr(SetupHub, "attempt_login", fake_attempt_login)
+
+    result = await process_user_input(
+        {
+            "host": "http://router",
+            "password": "secret",
+            CONF_PARALLEL_REQUESTS: True,
+        },
+        types.SimpleNamespace(),
+    )
+
+    assert result["data"][CONF_PARALLEL_REQUESTS] is True
+
+
+async def test_process_user_input_defaults_parallel_requests(monkeypatch) -> None:
+
+    def fake_init(self, host: str, hass: Any) -> None:
+        self.host = host
+        self.username = DEFAULT_USERNAME
+        self.router_mac = "00:00:00:00:00:00"
+        self.router_model = "mr200"
+        self.wan_interfaces = ["wan"]
+
+    async def fake_check_reachable(self) -> bool:
+        return True
+
+    async def fake_attempt_login(self, password: str) -> bool:
+        return True
+
+    monkeypatch.setattr(SetupHub, "__init__", fake_init)
+    monkeypatch.setattr(SetupHub, "check_reachable", fake_check_reachable)
+    monkeypatch.setattr(SetupHub, "attempt_login", fake_attempt_login)
+
+    result = await process_user_input(
+        {"host": "http://router", "password": "secret"},
+        types.SimpleNamespace(),
+    )
+
+    assert result["data"][CONF_PARALLEL_REQUESTS] is DEFAULT_PARALLEL_REQUESTS

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -16,14 +16,14 @@ def mock_api():
 
 
 @pytest.fixture
-def mock_hub(mock_api):
+def mock_hub(hass, mock_api):
     entry = AsyncMock()
     entry.options = {}
     entry.data = {"host": "http://192.168.8.1", "password": "pass"}
     entry.entry_id = "test_entry"
     entry.runtime_data = None
 
-    hub = GLinetHub(AsyncMock(), entry)
+    hub = GLinetHub(hass, entry)
     hub._api = mock_api
     return hub
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -14,6 +14,7 @@ def mock_api():
     api.fan = AsyncMock()
     return api
 
+
 @pytest.fixture
 def mock_hub(mock_api):
     entry = AsyncMock()
@@ -26,6 +27,7 @@ def mock_hub(mock_api):
     hub._api = mock_api
     return hub
 
+
 async def test_fetch_fan_status_success(mock_hub, mock_api):
     mock_api.fan.get_status = AsyncMock(return_value={"status": True, "speed": 1000})
     mock_api.fan.get_config = AsyncMock(return_value={"temperature": 75, "warn_temperature": 90})
@@ -36,6 +38,7 @@ async def test_fetch_fan_status_success(mock_hub, mock_api):
     assert mock_hub.fan_speed == 1000
     assert mock_hub.fan_temperature_threshold == 75
 
+
 async def test_fetch_fan_status_no_fan(mock_hub, mock_api):
 
     mock_api.fan.get_status = AsyncMock(side_effect=NonZeroResponse("Method not found"))
@@ -44,6 +47,7 @@ async def test_fetch_fan_status_no_fan(mock_hub, mock_api):
 
     assert mock_hub.fan_status is None
     assert mock_hub.fan_running is None
+
 
 async def test_set_fan_temperature(mock_hub, mock_api):
     mock_api.fan.set_config = AsyncMock(return_value={})

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -45,9 +45,7 @@ async def test_firewall_module_methods_use_expected_payloads() -> None:
 
     assert await client.firewall.get_rule_list() == {"res": [{"id": "rule-1"}]}
     assert await client.firewall.add_rule({"name": "Allow SSH"}) == {"ok": True}
-    assert await client.firewall.set_rule({"id": "rule-1", "name": "Allow SSH"}) == {
-        "ok": True
-    }
+    assert await client.firewall.set_rule({"id": "rule-1", "name": "Allow SSH"}) == {"ok": True}
     assert await client.firewall.remove_rule({"id": "rule-1"}) == {"ok": True}
     assert await client.firewall.get_acl_rule_list() == [{"name": "ACL"}]
     assert await client.firewall.add_acl_rule({"name": "ACL"}) == {"ok": True}
@@ -302,9 +300,7 @@ async def test_fetch_kmwan_status_stores_response() -> None:
     hub = GLinetHub.__new__(GLinetHub)
     hub._api = SimpleNamespace(system=SimpleNamespace(get_kmwan_status=object()))
     hub._invoke_optional_api = AsyncMock(
-        return_value={
-            "interfaces": [{"interface": "wan", "status_v4": 1, "status_v6": 1}]
-        }
+        return_value={"interfaces": [{"interface": "wan", "status_v4": 1, "status_v6": 1}]}
     )
 
     await hub.fetch_kmwan_status()
@@ -400,10 +396,6 @@ async def test_wan_access_switch_toggles_selected_access_type() -> None:
     await switch.async_turn_on()
     await switch.async_turn_off()
 
-    hub.set_wan_access.assert_any_await(
-        {"enable_ping": True, "enable_ssh": True}
-    )
-    hub.set_wan_access.assert_any_await(
-        {"enable_ping": False, "enable_ssh": True}
-    )
+    hub.set_wan_access.assert_any_await({"enable_ping": True, "enable_ssh": True})
+    hub.set_wan_access.assert_any_await({"enable_ping": False, "enable_ssh": True})
     assert hub.async_request_refresh.await_count == 2

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -477,9 +477,7 @@ async def test_scan_wifi_networks_stores_results(monkeypatch) -> None:
     hub._scanned_networks = []
     hub._last_wifi_scan = None
 
-    async def fake_scan_wifi_networks(
-        params: dict[str, Any]
-    ) -> list[dict[str, Any]]:
+    async def fake_scan_wifi_networks(params: dict[str, Any]) -> list[dict[str, Any]]:
         calls.append(params)
         return [
             {
@@ -625,9 +623,7 @@ async def test_set_repeater_band_updates_config(monkeypatch) -> None:
     called: list[Any] = []
 
     class RepeaterModule:
-        async def set_config(
-            self, params: dict[str, Any]
-        ) -> dict[str, Any]:
+        async def set_config(self, params: dict[str, Any]) -> dict[str, Any]:
             called.append(params.get("lock_band"))
             return {}
 
@@ -754,22 +750,22 @@ async def test_async_initialize_hub_cleans_up_orphaned_entities(monkeypatch) -> 
     hub._late_init_complete = True
     hub._factory_mac = "00:11:22:33:44:55"
 
-
     orphan_entry = types.SimpleNamespace(
         entity_id="sensor.glinet_cellular_signal",
         unique_id="glinet_sensor/00:11:22:33:44:55/cellular_signal",
-        domain="sensor"
+        domain="sensor",
     )
     valid_entry = types.SimpleNamespace(
         entity_id="sensor.glinet_uptime",
         unique_id="glinet_sensor/00:11:22:33:44:55/system_uptime",
-        domain="sensor"
+        domain="sensor",
     )
 
     mock_er = MagicMock()
     mock_er.async_remove = MagicMock()
 
     import homeassistant.helpers.entity_registry as er
+
     monkeypatch.setattr(er, "async_get", lambda _: mock_er)
     monkeypatch.setattr(
         er,
@@ -780,9 +776,7 @@ async def test_async_initialize_hub_cleans_up_orphaned_entities(monkeypatch) -> 
     hub.refresh_session_token = _noop
     hub.fetch_all_data = _noop
 
-
     await hub.async_initialize_hub()
-
 
     mock_er.async_remove.assert_called_once_with("sensor.glinet_cellular_signal")
 
@@ -984,6 +978,7 @@ async def test_async_initialize_hub_cleans_up_unselected_cellular_ip_sensors(
 
 async def test_fetch_connected_devices_respects_add_all_devices_option(monkeypatch) -> None:
     import custom_components.glinet_router.hub as hub_module
+
     monkeypatch.setattr(hub_module, "async_dispatcher_send", _noop_arg)
 
     hub = GLinetHub.__new__(GLinetHub)
@@ -994,12 +989,11 @@ async def test_fetch_connected_devices_respects_add_all_devices_option(monkeypat
     hub._entry = types.SimpleNamespace(entry_id="test_entry", unique_id="unique_id")
     hub.hass = MagicMock()
 
-
     mock_dr = MagicMock()
     mock_dr.async_get_device.return_value = None
     import homeassistant.helpers.device_registry as dr
-    monkeypatch.setattr(dr, "async_get", lambda _: mock_dr)
 
+    monkeypatch.setattr(dr, "async_get", lambda _: mock_dr)
 
     hub._api = types.SimpleNamespace(clients=types.SimpleNamespace(get_online=AsyncMock()))
     hub._invoke_api = AsyncMock(
@@ -1007,7 +1001,6 @@ async def test_fetch_connected_devices_respects_add_all_devices_option(monkeypat
     )
 
     await hub.fetch_connected_devices()
-
 
     assert "11:22:33:44:55:66" in hub._devices
     assert hub._devices["11:22:33:44:55:66"].is_known is False
@@ -1021,16 +1014,13 @@ async def test_async_initialize_hub_cleans_up_unknown_devices(monkeypatch) -> No
     hub._late_init_complete = True
     hub._factory_mac = "00:11:22:33:44:55"
 
-
     unknown_tracker = types.SimpleNamespace(
-        entity_id="device_tracker.unknown",
-        unique_id="aa:bb:cc:dd:ee:ff",
-        domain="device_tracker"
+        entity_id="device_tracker.unknown", unique_id="aa:bb:cc:dd:ee:ff", domain="device_tracker"
     )
     unknown_sensor = types.SimpleNamespace(
         entity_id="sensor.unknown_bandwidth",
         unique_id="glinet_client_sensor/aa:bb:cc:dd:ee:ff/download",
-        domain="sensor"
+        domain="sensor",
     )
 
     mock_er = MagicMock()
@@ -1038,6 +1028,7 @@ async def test_async_initialize_hub_cleans_up_unknown_devices(monkeypatch) -> No
 
     import homeassistant.helpers.device_registry as dr
     import homeassistant.helpers.entity_registry as er
+
     monkeypatch.setattr(er, "async_get", lambda _: mock_er)
     monkeypatch.setattr(
         er,
@@ -1045,12 +1036,9 @@ async def test_async_initialize_hub_cleans_up_unknown_devices(monkeypatch) -> No
         MagicMock(return_value=[unknown_tracker, unknown_sensor]),
     )
 
-
     mock_dr = MagicMock()
     mock_dr.async_get_device.return_value = types.SimpleNamespace(
-        id="device_id",
-        name="Test Device",
-        config_entries={"test_entry"}
+        id="device_id", name="Test Device", config_entries={"test_entry"}
     )
     mock_dr.async_remove_device = MagicMock()
     monkeypatch.setattr(dr, "async_get", lambda _: mock_dr)
@@ -1060,11 +1048,9 @@ async def test_async_initialize_hub_cleans_up_unknown_devices(monkeypatch) -> No
 
     await hub.async_initialize_hub()
 
-
     assert mock_er.async_remove.call_count == 2
     mock_er.async_remove.assert_any_call("device_tracker.unknown")
     mock_er.async_remove.assert_any_call("sensor.unknown_bandwidth")
-
 
     assert mock_dr.async_remove_device.call_count >= 1
     mock_dr.async_remove_device.assert_any_call("device_id")
@@ -1086,6 +1072,7 @@ async def test_fetch_wg_server_status(monkeypatch) -> None:
     assert hub.wg_server_status.enabled is True
     assert hub.wg_server_connected_users == 1
 
+
 async def test_start_wg_server(monkeypatch) -> None:
     hub = GLinetHub.__new__(GLinetHub)
     hub._settings = {}
@@ -1095,6 +1082,7 @@ async def test_start_wg_server(monkeypatch) -> None:
         async def start(self) -> dict[str, Any]:
             called.append("start")
             return {"ok": True}
+
         async def get_status(self) -> dict[str, Any]:
             return {"server": {"status": 1}}
 
@@ -1103,6 +1091,7 @@ async def test_start_wg_server(monkeypatch) -> None:
 
     await hub.start_wg_server()
     assert "start" in called
+
 
 async def test_stop_wg_server(monkeypatch) -> None:
     hub = GLinetHub.__new__(GLinetHub)
@@ -1113,6 +1102,7 @@ async def test_stop_wg_server(monkeypatch) -> None:
         async def stop(self) -> dict[str, Any]:
             called.append("stop")
             return {"ok": True}
+
         async def get_status(self) -> dict[str, Any]:
             return {"server": {"status": 0}}
 
@@ -1180,11 +1170,13 @@ def _make_entry(data: dict[str, Any] | None = None, options: dict[str, Any] | No
 def test_hub_uses_configured_scan_interval() -> None:
     from datetime import timedelta
 
-    entry = _make_entry(data={
-        "host": "http://192.168.8.1",
-        "password": "pass",
-        CONF_SCAN_INTERVAL: 60,
-    })
+    entry = _make_entry(
+        data={
+            "host": "http://192.168.8.1",
+            "password": "pass",
+            CONF_SCAN_INTERVAL: 60,
+        }
+    )
     hub = GLinetHub(MagicMock(), entry)
     assert hub.update_interval == timedelta(seconds=60)
 
@@ -1192,10 +1184,12 @@ def test_hub_uses_configured_scan_interval() -> None:
 def test_hub_defaults_scan_interval_when_not_configured() -> None:
     from datetime import timedelta
 
-    entry = _make_entry(data={
-        "host": "http://192.168.8.1",
-        "password": "pass",
-    })
+    entry = _make_entry(
+        data={
+            "host": "http://192.168.8.1",
+            "password": "pass",
+        }
+    )
     hub = GLinetHub(MagicMock(), entry)
     assert hub.update_interval == timedelta(seconds=30)
 
@@ -1218,11 +1212,13 @@ def test_hub_scan_interval_from_options_overrides_data() -> None:
 def test_apply_option_updates_changes_scan_interval() -> None:
     from datetime import timedelta
 
-    entry = _make_entry(data={
-        "host": "http://192.168.8.1",
-        "password": "pass",
-        CONF_SCAN_INTERVAL: 30,
-    })
+    entry = _make_entry(
+        data={
+            "host": "http://192.168.8.1",
+            "password": "pass",
+            CONF_SCAN_INTERVAL: 30,
+        }
+    )
     hub = GLinetHub(MagicMock(), entry)
     assert hub.update_interval == timedelta(seconds=30)
 
@@ -1233,10 +1229,12 @@ def test_apply_option_updates_changes_scan_interval() -> None:
 def test_apply_option_updates_without_scan_interval_keeps_default() -> None:
     from datetime import timedelta
 
-    entry = _make_entry(data={
-        "host": "http://192.168.8.1",
-        "password": "pass",
-    })
+    entry = _make_entry(
+        data={
+            "host": "http://192.168.8.1",
+            "password": "pass",
+        }
+    )
     hub = GLinetHub(MagicMock(), entry)
     assert hub.update_interval == timedelta(seconds=30)
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -164,6 +164,131 @@ async def test_fetch_cellular_status_extracts_apn() -> None:
     assert hub.cellular_status["modems"][0]["simcard"]["apn"] == "test.apn"
 
 
+async def test_fetch_cellular_status_fetches_sim_config_on_firmware_4_9() -> None:
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._cached_modem_info = None
+    hub._settings = {}
+    hub._cellular_status = {}
+    hub._default_modem_bus = None
+    hub._sw_version = "4.9.0"
+    hub._api = None
+    hub.is_firmware_4_9_or_above = True
+
+    info_response = {
+        "modems": [{"bus": "0001:01:00.0", "iccid": "8944200204977051694F", "slot": "1"}]
+    }
+    status_response = {
+        "modems": [
+            {
+                "bus": "0001:01:00.0",
+                "slot": "1",
+                "iccid": "8944200204977051694F",
+                "simcard": {"iccid": "8944200204977051694F"},
+            }
+        ]
+    }
+    sim_config_response = {
+        "8944200204977051694F": {
+            "manual": True,
+            "username": "",
+            "pincode": "",
+            "ip_type": 1,
+            "cid": 1,
+            "roaming": False,
+            "apn": "mob.asm.net",
+            "password": "",
+            "auth": "NONE",
+        }
+    }
+
+    sim_calls: list[str] = []
+    info_calls: list[Any] = []
+    status_calls: list[Any] = []
+
+    async def invoke_optional_api(callable_: Any) -> Any:
+        callable_()
+        if callable_ is hub._api.modem.get_info:
+            info_calls.append(callable_)
+            return info_response
+        if callable_ is hub._api.modem.get_status:
+            status_calls.append(callable_)
+            return status_response
+        if callable_.__name__ == "<lambda>" or "get_sim_config" in str(callable_):
+            # Capture the bus arg from the lambda's closure
+            sim_calls.append(str(callable_.__closure__[0].cell_contents))
+            return sim_config_response
+        return None
+
+    hub._invoke_optional_api = invoke_optional_api
+    hub._api = types.SimpleNamespace(
+        modem=types.SimpleNamespace(
+            get_info=lambda: info_response,
+            get_status=lambda: status_response,
+            get_sim_config=lambda bus: sim_config_response,
+        )
+    )
+
+    await hub.fetch_cellular_status()
+
+    # The APN from get_sim_config must land on the modem's simcard.
+    modem = hub.cellular_status["modems"][0]
+    assert modem["simcard"]["apn"] == "mob.asm.net"
+    assert sim_calls == ["0001:01:00.0"]
+
+
+async def test_fetch_cellular_status_keeps_4_8_apn_source() -> None:
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._cached_modem_info = None
+    hub._settings = {}
+    hub._cellular_status = {}
+    hub._default_modem_bus = None
+    hub._sw_version = "4.8.3"
+    hub._api = None
+    hub.is_firmware_4_9_or_above = False
+
+    info_response = {"modems": [{"bus": "0001:01:00.0", "iccid": "ICCID-1"}]}
+    status_response = {
+        "modems": [
+            {
+                "bus": "0001:01:00.0",
+                "iccid": "ICCID-1",
+                "simcard": {"iccid": "ICCID-1", "apn": "legacy.apn"},
+            }
+        ]
+    }
+
+    sim_calls: list[Any] = []
+
+    async def invoke_optional_api(callable_: Any) -> Any:
+        if callable_.__name__ == "<lambda>" or "get_sim_config" in str(callable_):
+            sim_calls.append(callable_)
+        return None
+
+    hub._invoke_optional_api = invoke_optional_api
+    hub._api = types.SimpleNamespace(
+        modem=types.SimpleNamespace(
+            get_info=lambda: info_response,
+            get_status=lambda: status_response,
+            get_sim_config=lambda bus: None,
+        )
+    )
+
+    # Stub the actual info/status responses inline.
+    queue = iter([info_response, status_response])
+
+    async def invoke(_: Any) -> Any:
+        return next(queue, None)
+
+    hub._invoke_optional_api = invoke
+
+    await hub.fetch_cellular_status()
+
+    modem = hub.cellular_status["modems"][0]
+    # 4.8 should NOT have called get_sim_config.
+    assert sim_calls == []
+    assert modem["simcard"]["apn"] == "legacy.apn"
+
+
 async def test_send_sms_uses_default_modem_bus() -> None:
     hub = GLinetHub.__new__(GLinetHub)
     hub._settings = {}
@@ -450,6 +575,54 @@ def test_parallel_requests_property_explicit_true() -> None:
     hub = GLinetHub.__new__(GLinetHub)
     hub._settings = {CONF_PARALLEL_REQUESTS: True}
     assert hub.parallel_requests is True
+
+
+def test_firmware_version_tuple_decodes_sw_version() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._sw_version = "4.9.0"
+    assert hub.firmware_version_tuple == (4, 9, 0, 0)
+
+    hub._sw_version = "4.8.1-rc2"
+    assert hub.firmware_version_tuple == (4, 8, 1, 2)
+
+    hub._sw_version = "UNKNOWN"
+    assert hub.firmware_version_tuple is None
+
+    hub._sw_version = ""
+    assert hub.firmware_version_tuple is None
+
+
+def test_is_firmware_4_9_or_above_uses_sw_version() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._api = None
+
+    hub._sw_version = "4.9.0"
+    assert hub.is_firmware_4_9_or_above is True
+
+    hub._sw_version = "4.9.1"
+    assert hub.is_firmware_4_9_or_above is True
+
+    hub._sw_version = "4.8.3"
+    assert hub.is_firmware_4_9_or_above is False
+
+    hub._sw_version = "4.8.0"
+    assert hub.is_firmware_4_9_or_above is False
+
+    # Placeholder values (pre-init) should fall back to the cached API
+    # firmware version so the property can be evaluated early in setup.
+    hub._sw_version = "UNKNOWN"
+    hub._api = types.SimpleNamespace(_firmware_version=(4, 9, 0, 0))
+    assert hub.is_firmware_4_9_or_above is True
+
+    hub._api = types.SimpleNamespace(_firmware_version=(4, 8, 0, 0))
+    assert hub.is_firmware_4_9_or_above is False
+
+    hub._api = types.SimpleNamespace(_firmware_version=None)
+    assert hub.is_firmware_4_9_or_above is False
 
 
 async def test_fetch_all_data_with_no_optional_features_still_runs_core_fetches(
@@ -959,6 +1132,118 @@ async def test_async_initialize_hub_cleans_up_orphaned_entities(monkeypatch) -> 
     await hub.async_initialize_hub()
 
     mock_er.async_remove.assert_called_once_with("sensor.glinet_cellular_signal")
+
+
+async def test_async_initialize_hub_removes_legacy_cellular_sensors_on_firmware_4_9(
+    monkeypatch,
+) -> None:
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._settings = {CONF_ENABLED_FEATURES: ["cellular"]}
+    hub._entry = types.SimpleNamespace(entry_id="test_entry")
+    hub.hass = MagicMock()
+    hub._late_init_complete = True
+    hub._factory_mac = "00:11:22:33:44:55"
+    hub._sw_version = "4.9.0"
+    hub._api = None
+
+    legacy_signal = types.SimpleNamespace(
+        entity_id="sensor.glinet_cellular_signal",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_signal",
+        domain="sensor",
+    )
+    legacy_rssi = types.SimpleNamespace(
+        entity_id="sensor.glinet_cellular_rssi",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_rssi",
+        domain="sensor",
+    )
+    # IPv4/IPv6 sensors stay on 4.9+ because the bodyless
+    # ``modem/get_network_info`` response still provides the IP.
+    kept_ipv4 = types.SimpleNamespace(
+        entity_id="sensor.cellular_wan_ipv4",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_ipv4",
+        domain="sensor",
+    )
+    kept_rsrp = types.SimpleNamespace(
+        entity_id="sensor.glinet_cellular_rsrp",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_rsrp",
+        domain="sensor",
+    )
+
+    mock_er = MagicMock()
+    mock_er.async_remove = MagicMock()
+
+    import homeassistant.helpers.entity_registry as er
+
+    monkeypatch.setattr(er, "async_get", lambda _: mock_er)
+    monkeypatch.setattr(
+        er,
+        "async_entries_for_config_entry",
+        MagicMock(
+            return_value=[
+                legacy_signal,
+                legacy_rssi,
+                kept_ipv4,
+                kept_rsrp,
+            ]
+        ),
+    )
+
+    hub.refresh_session_token = _noop
+    hub.fetch_all_data = _noop
+
+    await hub.async_initialize_hub()
+
+    assert mock_er.async_remove.call_count == 2
+    mock_er.async_remove.assert_any_call("sensor.glinet_cellular_signal")
+    mock_er.async_remove.assert_any_call("sensor.glinet_cellular_rssi")
+    # The IPv4 sensor and other cellular sensors must remain registered.
+    for call in mock_er.async_remove.call_args_list:
+        assert call.args[0] != "sensor.cellular_wan_ipv4"
+        assert call.args[0] != "sensor.glinet_cellular_rsrp"
+
+
+async def test_async_initialize_hub_keeps_legacy_cellular_sensors_on_firmware_4_8(
+    monkeypatch,
+) -> None:
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._settings = {CONF_ENABLED_FEATURES: ["cellular"]}
+    hub._entry = types.SimpleNamespace(entry_id="test_entry")
+    hub.hass = MagicMock()
+    hub._late_init_complete = True
+    hub._factory_mac = "00:11:22:33:44:55"
+    hub._sw_version = "4.8.3"
+    hub._api = None
+
+    legacy_signal = types.SimpleNamespace(
+        entity_id="sensor.glinet_cellular_signal",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_signal",
+        domain="sensor",
+    )
+    legacy_rssi = types.SimpleNamespace(
+        entity_id="sensor.glinet_cellular_rssi",
+        unique_id="glinet_sensor/00:11:22:33:44:55/cellular_rssi",
+        domain="sensor",
+    )
+
+    mock_er = MagicMock()
+    mock_er.async_remove = MagicMock()
+
+    import homeassistant.helpers.entity_registry as er
+
+    monkeypatch.setattr(er, "async_get", lambda _: mock_er)
+    monkeypatch.setattr(
+        er,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[legacy_signal, legacy_rssi]),
+    )
+
+    hub.refresh_session_token = _noop
+    hub.fetch_all_data = _noop
+
+    await hub.async_initialize_hub()
+
+    # Neither the cellular signal nor the RSSI sensor is removed on 4.8.
+    assert mock_er.async_remove.call_count == 0
 
 
 async def test_async_initialize_hub_cleans_up_repeater_entities_when_disabled(

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -41,7 +41,6 @@ async def _invoke_api_empty_clients(_: Any) -> dict[str, dict[str, Any]]:
 
 
 def test_router_traffic_sensors_sum_all_connected_clients() -> None:
-    """Traffic properties should aggregate from raw API data, not tracked devices."""
     hub = GLinetHub.__new__(GLinetHub)
     hub._devices = {}
     hub._all_connected_clients = {
@@ -56,7 +55,6 @@ def test_router_traffic_sensors_sum_all_connected_clients() -> None:
 
 
 def test_router_traffic_includes_untracked_devices() -> None:
-    """Traffic totals must include devices not tracked by HA (not in _devices)."""
     hub = GLinetHub.__new__(GLinetHub)
     # Only one device is tracked
     hub._devices = {"aa:bb:cc:dd:ee:ff": ClientDeviceInfo("aa:bb:cc:dd:ee:ff")}
@@ -270,6 +268,188 @@ async def test_fetch_all_data_skips_disabled_features(monkeypatch) -> None:
     assert hub._tailscale_connection is None
     assert hub._cellular_status == {}
     assert hub._modems == {}
+
+
+async def test_fetch_all_data_runs_tasks_in_parallel_when_enabled(
+    monkeypatch,
+) -> None:
+    import asyncio
+
+    from custom_components.glinet_router.const import CONF_PARALLEL_REQUESTS
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._settings = {CONF_ENABLED_FEATURES: [], CONF_PARALLEL_REQUESTS: True}
+    hub._entry = types.SimpleNamespace(entry_id="test_entry")
+    hub._host = "192.168.8.1"
+    hub._last_upgrade_check = None
+    hub.hass = object()
+    hub.refresh_session_token = _noop
+
+    started: list[str] = []
+    completed: list[str] = []
+    events = asyncio.Event()
+
+    async def make_slow_fetch(name: str) -> Any:
+        async def _run() -> None:
+            started.append(name)
+            await events.wait()
+            completed.append(name)
+
+        return _run
+
+    async def fake_fetch_system_status() -> None:
+        started.append("system")
+        await events.wait()
+        completed.append("system")
+
+    async def fake_fetch_kmwan_status() -> None:
+        started.append("kmwan")
+        await events.wait()
+        completed.append("kmwan")
+
+    async def fake_fetch_connected_devices() -> None:
+        started.append("clients")
+        await events.wait()
+        completed.append("clients")
+
+    async def fake_fetch_wifi_interfaces() -> None:
+        started.append("wifi")
+        await events.wait()
+        completed.append("wifi")
+
+    async def fake_fetch_fan_status() -> None:
+        started.append("fan")
+        await events.wait()
+        completed.append("fan")
+
+    async def fake_fetch_led_status() -> None:
+        started.append("led")
+        await events.wait()
+        completed.append("led")
+
+    hub.fetch_system_status = fake_fetch_system_status
+    hub.fetch_kmwan_status = fake_fetch_kmwan_status
+    hub.fetch_connected_devices = fake_fetch_connected_devices
+    hub.fetch_wifi_interfaces = fake_fetch_wifi_interfaces
+    hub.fetch_fan_status = fake_fetch_fan_status
+    hub.fetch_led_status = fake_fetch_led_status
+
+    async def _release() -> None:
+        # Give the loop a moment so all the per-feature tasks are
+        # scheduled and ``asyncio.gather`` is collecting them.
+        await asyncio.sleep(0)
+        events.set()
+
+    release_task = asyncio.create_task(_release())
+    await hub.fetch_all_data()
+    await release_task
+
+    # Sequential order would have each fetch finish before the next
+    # starts. With ``asyncio.gather`` all six core fetches start before
+    # any of them completes.
+    assert set(started) == {"system", "kmwan", "clients", "wifi", "fan", "led"}
+    assert completed == []  # none completed until the event was set
+
+
+async def test_fetch_all_data_runs_tasks_sequentially_by_default(
+    monkeypatch,
+) -> None:
+    import asyncio
+
+    from custom_components.glinet_router.const import CONF_PARALLEL_REQUESTS
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._settings = {
+        CONF_ENABLED_FEATURES: [],
+        CONF_PARALLEL_REQUESTS: False,  # explicit
+    }
+    hub._entry = types.SimpleNamespace(entry_id="test_entry")
+    hub._host = "192.168.8.1"
+    hub._last_upgrade_check = None
+    hub.hass = object()
+    hub.refresh_session_token = _noop
+
+    order: list[str] = []
+    started: dict[str, asyncio.Event] = {}
+    completed: dict[str, asyncio.Event] = {}
+
+    async def _ordered_fetch(name: str) -> None:
+        order.append(f"{name}:start")
+        # Signal that we started, then wait for the test to release us.
+        started[name].set()
+        await completed[name].wait()
+        order.append(f"{name}:end")
+
+    for name in (
+        "system",
+        "kmwan",
+        "clients",
+        "wifi",
+        "fan",
+        "led",
+    ):
+        started[name] = asyncio.Event()
+        completed[name] = asyncio.Event()
+        setattr(
+            hub,
+            f"fetch_{name.replace('clients', 'connected_devices').replace('led', 'led_status')}",
+            _ordered_fetch(name),
+        )
+
+    # Correct attribute names are: fetch_system_status, fetch_kmwan_status,
+    # fetch_connected_devices, fetch_wifi_interfaces, fetch_fan_status,
+    # fetch_led_status. The previous loop misnamed some attributes; the
+    # block below reassigns them by the right name.
+    expected_names = [
+        "system_status",
+        "kmwan_status",
+        "connected_devices",
+        "wifi_interfaces",
+        "fan_status",
+        "led_status",
+    ]
+    for name, attr in zip(
+        ("system", "kmwan", "clients", "wifi", "fan", "led"),
+        expected_names,
+        strict=True,
+    ):
+        setattr(hub, f"fetch_{attr}", _ordered_fetch(name))
+
+    async def _drive() -> None:
+        # Wait until the first fetch has started, then release it. Repeat
+        # for the rest. If execution were parallel, the test would fail
+        # because later fetches would not start before earlier ones end.
+        for name in ("system", "kmwan", "clients", "wifi", "fan", "led"):
+            await started[name].wait()
+            completed[name].set()
+
+    drive_task = asyncio.create_task(_drive())
+    await hub.fetch_all_data()
+    await drive_task
+
+    # Each fetch fully completes before the next one starts.
+    expected_order = []
+    for name in ("system", "kmwan", "clients", "wifi", "fan", "led"):
+        expected_order.append(f"{name}:start")
+        expected_order.append(f"{name}:end")
+    assert order == expected_order
+
+
+def test_parallel_requests_property_default() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._settings = {}
+    assert hub.parallel_requests is False
+
+
+def test_parallel_requests_property_explicit_true() -> None:
+    from custom_components.glinet_router.const import CONF_PARALLEL_REQUESTS
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._settings = {CONF_PARALLEL_REQUESTS: True}
+    assert hub.parallel_requests is True
 
 
 async def test_fetch_all_data_with_no_optional_features_still_runs_core_fetches(

--- a/tests/test_led.py
+++ b/tests/test_led.py
@@ -8,23 +8,21 @@ from tests.test_api_client import FakeSession
 
 @pytest.fixture
 def led_config_response() -> dict[str, Any]:
-    return {
-        "result": {
-            "led_enable": True
-        }
-    }
+    return {"result": {"led_enable": True}}
+
 
 async def test_led_get_config(led_config_response: dict[str, Any]) -> None:
     session = FakeSession([led_config_response])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     config = await client.led.get_config()
     assert config["led_enable"] is True
+
 
 async def test_led_set_config() -> None:
     session = FakeSession([{"result": None}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     await client.led.set_config({"led_enable": False})
     expected_params = ["sid-1", "led", "set_config", {"led_enable": False}]
     assert session.requests[0]["json"]["params"] == expected_params

--- a/tests/test_mcu.py
+++ b/tests/test_mcu.py
@@ -22,9 +22,7 @@ async def test_mcu_module_methods_use_expected_payloads() -> None:
     )
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
 
-    assert await client.mcu.get_battery_config() == {
-        "capacity": {"enable": False, "value": "10"}
-    }
+    assert await client.mcu.get_battery_config() == {"capacity": {"enable": False, "value": "10"}}
     assert await client.mcu.set_battery_config({"capacity": {"enable": True, "value": 12}}) == {
         "err_code": 0,
         "err_msg": "OK",
@@ -67,9 +65,7 @@ async def test_hub_mcu_actions_call_api_and_cache_config() -> None:
     hub._invoke_api = invoke_api
     hub._invoke_optional_api = invoke_optional_api
 
-    assert await hub.get_mcu_battery_config() == {
-        "capacity": {"enable": True, "value": 20}
-    }
+    assert await hub.get_mcu_battery_config() == {"capacity": {"enable": True, "value": 20}}
     await hub.set_mcu_battery_config({"capacity": {"enable": False, "value": 10}})
     assert await hub.get_mcu_oled_config() == {"screen_display": {"main": True, "lan": False}}
     await hub.set_mcu_oled_config({"lan": True})

--- a/tests/test_modem_49.py
+++ b/tests/test_modem_49.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.glinet_router.api.client import GLinetApiClient
+from custom_components.glinet_router.api.const import FIRMWARE_4_9
+from custom_components.glinet_router.api.modules.modem import (
+    ModemModule,
+    _index_networks_by_bus_slot,
+    _target_lookup_key,
+)
+from tests.test_api_client import FakeSession
+
+
+def _make_module(responses: list[Any]) -> tuple[ModemModule, FakeSession]:
+    session = FakeSession(responses)
+    client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
+    client._firmware_version = FIRMWARE_4_9
+    return client.modem, session
+
+
+def test_target_lookup_key_coerces_slot_to_string() -> None:
+    assert _target_lookup_key({"bus": "0001:01:00.0", "slot": 1}) == (
+        "0001:01:00.0",
+        "1",
+    )
+    assert _target_lookup_key({"bus": "0001:01:00.0", "slot": "2"}) == (
+        "0001:01:00.0",
+        "2",
+    )
+    assert _target_lookup_key({"bus": "0001:01:00.0"}) == ("0001:01:00.0", "")
+
+
+def test_index_networks_by_bus_slot_indexes_list_payload() -> None:
+    response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "network_interface": "modem_0001_s1",
+                "bus": "0001:01:00.0",
+                "slot": "1",
+                "ipv4": {"ip": "10.77.58.41", "gateway": "10.77.58.42"},
+            },
+            {
+                "network_interface": "modem_0001_s2",
+                "bus": "0001:01:00.0",
+                "slot": "2",
+                "ipv4": {"ip": "10.77.58.45"},
+            },
+        ],
+    }
+
+    indexed = _index_networks_by_bus_slot(response)
+
+    assert set(indexed) == {("0001:01:00.0", "1"), ("0001:01:00.0", "2")}
+    assert indexed[("0001:01:00.0", "1")]["ipv4"]["ip"] == "10.77.58.41"
+    assert indexed[("0001:01:00.0", "2")]["ipv4"]["ip"] == "10.77.58.45"
+
+
+def test_index_networks_by_bus_slot_handles_bare_dict_payload() -> None:
+    indexed = _index_networks_by_bus_slot(
+        {
+            "bus": "0001:01:00.0",
+            "slot": "1",
+            "ipv4": {"ip": "10.77.58.41"},
+        }
+    )
+
+    assert indexed == {
+        ("0001:01:00.0", "1"): {"bus": "0001:01:00.0", "slot": "1", "ipv4": {"ip": "10.77.58.41"}}
+    }
+
+
+def test_index_networks_by_bus_slot_skips_records_without_bus_or_slot() -> None:
+    indexed = _index_networks_by_bus_slot(
+        {
+            "networks": [
+                {"bus": "0001:01:00.0", "slot": "1"},
+                {"slot": "2"},  # missing bus
+                {"bus": "0001:01:00.0"},  # missing slot
+            ]
+        }
+    )
+
+    assert indexed == {("0001:01:00.0", "1"): {"bus": "0001:01:00.0", "slot": "1"}}
+
+
+async def test_get_status_49_uses_bodyless_network_calls() -> None:
+    targets_response = {"interfaces": ["modem_0001_s1"]}
+    signals_response = {"signals": [{"slot": "1", "strength": 70, "timestamp": 1}]}
+    network_status_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "bus": "0001:01:00.0",
+                "slot": "1",
+                "status": 0,
+                "iccid": "12345",
+                "protocol": "ipv4",
+            }
+        ],
+    }
+    network_info_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "network_interface": "modem_0001_s1",
+                "bus": "0001:01:00.0",
+                "slot": "1",
+                "ipv4": {
+                    "ip": "10.77.58.41",
+                    "gateway": "10.77.58.42",
+                    "netmask": "255.255.255.252",
+                },
+                "ipv6": {"ip": "2001:db8::42"},
+                "cell_info": {"mode": "NR5G-NSA", "band": 78},
+            }
+        ],
+    }
+
+    modem, session = _make_module(
+        [
+            {"result": targets_response},
+            {"result": signals_response},
+            {"result": network_status_response},
+            {"result": network_info_response},
+        ]
+    )
+
+    result = await modem.get_status()
+
+    assert len(result["modems"]) == 1
+    modem_record = result["modems"][0]
+    assert modem_record["bus"] == "0001:01:00.0"
+    assert modem_record["slot"] == "1"
+    assert modem_record["network"]["ipv4"]["ip"] == "10.77.58.41"
+    assert modem_record["network"]["ipv6"]["ip"] == "2001:db8::42"
+    assert modem_record["network_interface"] == "modem_0001_s1"
+
+    network_status_call = session.requests[2]
+    network_info_call = session.requests[3]
+    assert network_status_call["json"]["params"] == [
+        "sid-1",
+        "call",
+        ["modem", "get_network_status", {}],
+    ]
+    assert network_info_call["json"]["params"] == [
+        "sid-1",
+        "call",
+        ["modem", "get_network_info", {}],
+    ]
+
+
+async def test_get_status_49_picks_correct_entry_per_target() -> None:
+    targets_response = {"interfaces": ["modem_0001_s1", "modem_0001_s2"]}
+    signals_response = {"signals": []}
+    network_status_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {"bus": "0001:01:00.0", "slot": "1", "status": 0, "iccid": "AAA"},
+            {"bus": "0001:01:00.0", "slot": "2", "status": 0, "iccid": "BBB"},
+        ],
+    }
+    network_info_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "bus": "0001:01:00.0",
+                "slot": "1",
+                "network_interface": "modem_0001_s1",
+                "ipv4": {"ip": "10.77.58.41"},
+            },
+            {
+                "bus": "0001:01:00.0",
+                "slot": "2",
+                "network_interface": "modem_0001_s2",
+                "ipv4": {"ip": "10.77.58.49"},
+            },
+        ],
+    }
+
+    modem, _ = _make_module(
+        [
+            {"result": targets_response},
+            {"result": signals_response},
+            {"result": network_status_response},
+            {"result": network_info_response},
+        ]
+    )
+
+    result = await modem.get_status()
+    modems_by_slot = {m["slot"]: m for m in result["modems"]}
+
+    assert modems_by_slot["1"]["network"]["ipv4"]["ip"] == "10.77.58.41"
+    assert modems_by_slot["2"]["network"]["ipv4"]["ip"] == "10.77.58.49"
+    assert modems_by_slot["1"]["network_interface"] == "modem_0001_s1"
+    assert modems_by_slot["2"]["network_interface"] == "modem_0001_s2"
+
+
+async def test_get_status_49_falls_back_to_per_target_call() -> None:
+    targets_response = {"interfaces": ["modem_0001_s1"]}
+    signals_response = {"signals": []}
+    empty_bodyless = {"ret": 0, "resp": "Success", "networks": []}
+    fallback_status = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {"bus": "0001:01:00.0", "slot": "1", "status": 0, "iccid": "ZZZ"},
+        ],
+    }
+    fallback_info = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {"bus": "0001:01:00.0", "slot": "1", "ipv4": {"ip": "10.77.58.99"}},
+        ],
+    }
+
+    modem, session = _make_module(
+        [
+            {"result": targets_response},
+            {"result": signals_response},
+            {"result": empty_bodyless},
+            {"result": empty_bodyless},
+            {"result": fallback_status},
+            {"result": fallback_info},
+        ]
+    )
+
+    result = await modem.get_status()
+    assert len(result["modems"]) == 1
+    assert result["modems"][0]["network"]["ipv4"]["ip"] == "10.77.58.99"
+
+    per_target_status = session.requests[4]
+    assert per_target_status["json"]["params"][2] == [
+        "modem",
+        "get_network_status",
+        {"bus": "0001:01:00.0", "slot": "1"},
+    ]
+
+
+def test_bus_aliases_expand_pci_to_short_form() -> None:
+    from custom_components.glinet_router.api.modules.modem import _bus_aliases
+
+    assert _bus_aliases("0001:01:00.0") == ["0001:01:00.0", "0001", "0001:01:00"]
+    assert _bus_aliases("0001-0200.0") == ["0001-0200.0", "0001-0200"]
+    assert _bus_aliases("0001") == ["0001"]
+    assert _bus_aliases("") == [""]
+
+
+def test_targets_from_interface_handles_short_bus_form() -> None:
+    from custom_components.glinet_router.api.modules.modem import _targets_from_interface
+
+    assert _targets_from_interface("modem_0001_s1") == [{"bus": "0001", "slot": 1}]
+    assert _targets_from_interface("modem_0001_0200_0_s1") == [{"bus": "0001-0200.0", "slot": 1}]
+
+
+async def test_get_status_49_resolves_ip_when_bus_uses_short_form() -> None:
+    targets_response = {"interfaces": ["modem_0001_s1"]}
+    signals_response = {"signals": []}
+    network_status_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "traffic_total": "2515490956",
+                "protocol": "qcm",
+                "slot": "1",
+                "iccid": "8944200204977051694F",
+                "dial_status": 0,
+                "call_reason": "Success",
+                "bus": "0001:01:00.0",
+                "callcode": 0,
+                "status": 0,
+                "calltype": 0,
+            }
+        ],
+    }
+    network_info_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "network_interface": "modem_0001_s1",
+                "bus": "0001:01:00.0",
+                "ip_type": 1,
+                "slot": "1",
+                "cell_info": {
+                    "band": 78,
+                    "type": "servingcell",
+                    "rsrp_level": 4,
+                    "sinr": "22",
+                    "tx_channel": "",
+                    "rsrq_level": 4,
+                    "rsrq": "-10",
+                    "dl_bandwidth": "100MHz",
+                    "mode": "NR5G-NSA",
+                    "sinr_level": 4,
+                    "rsrp": "-86",
+                },
+                "network_mode": "AUTO",
+                "mtu_sync": 0,
+                "ipv4": {
+                    "netmask": "255.255.255.252",
+                    "gateway": "10.77.58.42",
+                    "dns": ["188.31.250.128", "188.31.250.129"],
+                    "ip": "10.77.58.41",
+                },
+            }
+        ],
+    }
+
+    modem, _ = _make_module(
+        [
+            {"result": targets_response},
+            {"result": signals_response},
+            {"result": network_status_response},
+            {"result": network_info_response},
+        ]
+    )
+
+    result = await modem.get_status()
+    assert len(result["modems"]) == 1
+    modem_record = result["modems"][0]
+    assert modem_record["network"]["ipv4"]["ip"] == "10.77.58.41"
+    assert modem_record["bus"] == "0001:01:00.0"
+    assert modem_record["slot"] == "1"
+    assert modem_record["network_interface"] == "modem_0001_s1"
+
+
+async def test_get_sim_config_calls_endpoint_with_bus() -> None:
+    expected = {
+        "8944200204977051694F": {
+            "manual": True,
+            "username": "",
+            "pincode": "",
+            "ip_type": 1,
+            "cid": 1,
+            "roaming": False,
+            "apn": "mob.asm.net",
+            "password": "",
+            "auth": "NONE",
+        }
+    }
+
+    modem, session = _make_module([{"result": expected}])
+
+    result = await modem.get_sim_config("0001:01:00.0")
+
+    assert result == expected
+    request = session.requests[0]
+    assert request["json"]["params"] == [
+        "sid-1",
+        "call",
+        ["modem", "get_sim_config", {"bus": "0001:01:00.0"}],
+    ]
+
+
+async def test_get_sms_list_49_uses_full_pci_bus() -> None:
+    targets_response = {"interfaces": ["modem_0001_s1"]}
+    signals_response = {"signals": []}
+    network_status_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "bus": "0001:01:00.0",
+                "slot": "1",
+                "iccid": "8944200204977051694F",
+                "status": 0,
+            }
+        ],
+    }
+    network_info_response = {
+        "ret": 0,
+        "resp": "Success",
+        "networks": [
+            {
+                "network_interface": "modem_0001_s1",
+                "bus": "0001:01:00.0",
+                "slot": "1",
+                "ipv4": {"ip": "10.77.58.41"},
+            }
+        ],
+    }
+    sms_response = {
+        "list": [
+            {
+                "name": "GMS1.gcKIin",
+                "phone_number": "447587541306",
+                "body": "Hello",
+                "status": 0,
+                "date": "26-07-15 13:48:50",
+                "bus": "0001:01:00.0",
+                "slot": 1,
+            }
+        ]
+    }
+
+    modem, session = _make_module(
+        [
+            {"result": targets_response},
+            {"result": signals_response},
+            {"result": network_status_response},
+            {"result": network_info_response},
+            {"result": sms_response},
+        ]
+    )
+
+    result = await modem.get_sms_list()
+
+    assert len(result) == 1
+    assert result[0]["body"] == "Hello"
+    assert result[0]["phone_number"] == "447587541306"
+
+    sms_call = session.requests[4]
+    assert sms_call["json"]["params"] == [
+        "sid-1",
+        "call",
+        ["modem", "get_sms_list", {"bus": "0001:01:00.0"}],
+    ]
+
+
+async def test_get_sms_list_49_falls_back_to_short_bus_when_no_network_info() -> None:
+    targets_response = {"interfaces": ["modem_0001_s1"]}
+    signals_response = {"signals": []}
+    empty_bodyless = {"ret": 0, "resp": "Success", "networks": []}
+    sms_response = {
+        "list": [
+            {
+                "name": "GMS1.gcKIin",
+                "phone_number": "447587541306",
+                "body": "Hello",
+                "status": 0,
+                "date": "26-07-15 13:48:50",
+            }
+        ]
+    }
+
+    modem, _ = _make_module(
+        [
+            {"result": targets_response},
+            {"result": signals_response},
+            {"result": empty_bodyless},
+            {"result": empty_bodyless},
+            {"result": sms_response},
+        ]
+    )
+
+    result = await modem.get_sms_list()
+
+    assert len(result) == 1
+    assert result[0]["body"] == "Hello"
+
+
+def test_send_sms_coerces_string_slot_to_int() -> None:
+    """Firmware 4.9+ only tags the sent message with the SIM when
+    ``slot`` is an integer. The bodyless ``get_network_status`` response
+    surfaces it as a string, so the integration must coerce it.
+    """
+
+    async def run() -> None:
+        modem, session = _make_module(
+            [
+                {"result": {"ret": 0, "resp": "Success"}},
+            ]
+        )
+        await modem.send_sms(
+            "0001:01:00.0",
+            "+447587541306",
+            "Test Message",
+            slot="1",
+        )
+
+        last_request = session.requests[-1]
+        params = last_request["json"]["params"]
+        assert params[2] == "send_sms"
+        assert params[3]["bus"] == "0001:01:00.0"
+        assert params[3]["slot"] == 1
+        assert isinstance(params[3]["slot"], int)
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_send_sms_passes_int_slot_unchanged() -> None:
+    async def run() -> None:
+        modem, session = _make_module(
+            [
+                {"result": {"ret": 0, "resp": "Success"}},
+            ]
+        )
+        await modem.send_sms(
+            "0001:01:00.0",
+            "+447587541306",
+            "Test Message",
+            slot=1,
+        )
+
+        last_request = session.requests[-1]
+        params = last_request["json"]["params"]
+        assert params[3]["slot"] == 1
+        assert isinstance(params[3]["slot"], int)
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_send_sms_omits_slot_when_none() -> None:
+    async def run() -> None:
+        modem, session = _make_module(
+            [
+                {"result": {"ret": 0, "resp": "Success"}},
+            ]
+        )
+        await modem.send_sms(
+            "0001:01:00.0",
+            "+447587541306",
+            "Test Message",
+        )
+
+        last_request = session.requests[-1]
+        params = last_request["json"]["params"]
+        assert "slot" not in params[3]
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_remove_sms_does_not_send_slot_field() -> None:
+    async def run() -> None:
+        modem, session = _make_module(
+            [
+                {"result": {"ret": 0, "resp": "Success"}},
+            ]
+        )
+        await modem.remove_sms(
+            "0001:01:00.0",
+            scope=10,
+            message_id="GMS1.gcKIin",
+        )
+
+        last_request = session.requests[-1]
+        params = last_request["json"]["params"]
+        assert params[2] == "remove_sms"
+        assert params[3]["bus"] == "0001:01:00.0"
+        assert params[3]["scope"] == 10
+        assert params[3]["name"] == "GMS1.gcKIin"
+        assert "slot" not in params[3]
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_remove_sms_omits_name_when_no_message_id() -> None:
+    async def run() -> None:
+        modem, session = _make_module(
+            [
+                {"result": {"ret": 0, "resp": "Success"}},
+            ]
+        )
+        await modem.remove_sms(
+            "0001:01:00.0",
+            scope=0,
+        )
+
+        last_request = session.requests[-1]
+        params = last_request["json"]["params"]
+        assert params[2] == "remove_sms"
+        assert params[3] == {"bus": "0001:01:00.0", "scope": 0}
+
+    import asyncio
+
+    asyncio.run(run())

--- a/tests/test_ovpn.py
+++ b/tests/test_ovpn.py
@@ -19,8 +19,8 @@ def vpn_client_tunnel_response() -> dict[str, Any]:
                         "type": "openvpn",
                         "client_id": 2034,
                         "group_id": 65395,
-                        "via": "ovpnclient1"
-                    }
+                        "via": "ovpnclient1",
+                    },
                 }
             ]
         }
@@ -29,13 +29,7 @@ def vpn_client_tunnel_response() -> dict[str, Any]:
 
 @pytest.fixture
 def ovpn_groups_response() -> dict[str, Any]:
-    return {
-        "result": {
-            "groups": [
-                {"group_id": 65395, "group_name": "NordVPN"}
-            ]
-        }
-    }
+    return {"result": {"groups": [{"group_id": 65395, "group_name": "NordVPN"}]}}
 
 
 @pytest.fixture
@@ -47,7 +41,7 @@ def ovpn_config_list_response() -> dict[str, Any]:
                     "client_id": 2034,
                     "name": "gr69.nordvpn.com.udp",
                     "location": "Greece, Athens",
-                    "remote": ["156.67.94.2:1194"]
+                    "remote": ["156.67.94.2:1194"],
                 }
             ]
         }
@@ -57,13 +51,11 @@ def ovpn_config_list_response() -> dict[str, Any]:
 async def test_ovpn_client_get_clients(
     ovpn_groups_response: dict[str, Any],
     ovpn_config_list_response: dict[str, Any],
-    vpn_client_tunnel_response: dict[str, Any]
+    vpn_client_tunnel_response: dict[str, Any],
 ) -> None:
-    session = FakeSession([
-        ovpn_groups_response,
-        ovpn_config_list_response,
-        vpn_client_tunnel_response
-    ])
+    session = FakeSession(
+        [ovpn_groups_response, ovpn_config_list_response, vpn_client_tunnel_response]
+    )
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
 
     clients = await client.ovpn_client.get_ovpn_clients()
@@ -80,17 +72,17 @@ async def test_ovpn_client_start() -> None:
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
 
     await client.ovpn_client.start(65395, 2034, tunnel_id=10)
-    
+
     # Check start call (should be set_tunnel)
     expected_params = [
-        "sid-1", 
-        "vpn-client", 
-        "set_tunnel", 
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
         {
-            "enabled": True, 
+            "enabled": True,
             "tunnel_id": 10,
-            "via": {"group_id": 65395, "client_id": 2034, "type": "openvpn"}
-        }
+            "via": {"group_id": 65395, "client_id": 2034, "type": "openvpn"},
+        },
     ]
     assert session.requests[0]["json"]["params"] == expected_params
 
@@ -100,14 +92,9 @@ async def test_ovpn_client_stop() -> None:
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
 
     await client.ovpn_client.stop(65395, 2034, tunnel_id=10)
-    
+
     # Check stop call (should be set_tunnel)
-    expected_params = [
-        "sid-1", 
-        "vpn-client", 
-        "set_tunnel", 
-        {"enabled": False, "tunnel_id": 10}
-    ]
+    expected_params = ["sid-1", "vpn-client", "set_tunnel", {"enabled": False, "tunnel_id": 10}]
     assert session.requests[0]["json"]["params"] == expected_params
 
 
@@ -118,7 +105,7 @@ async def test_ovpn_server_get_status() -> None:
             "initialization": True,
             "tunnel_ip": "10.8.0.1",
             "rx_bytes": 500,
-            "tx_bytes": 600
+            "tx_bytes": 600,
         }
     }
     session = FakeSession([response, {"result": {"user_list": []}}])

--- a/tests/test_parental_control.py
+++ b/tests/test_parental_control.py
@@ -296,8 +296,7 @@ async def test_async_initialize_hub_cleans_up_parental_control_entities(
         SimpleNamespace(
             entity_id="binary_sensor.parental_override",
             unique_id=(
-                "glinet_binary_sensor/00:11:22:33:44:55/"
-                "parental_control_group_group1_override"
+                "glinet_binary_sensor/00:11:22:33:44:55/parental_control_group_group1_override"
             ),
             domain="binary_sensor",
         ),

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -40,7 +40,7 @@ def _install_sensor_dependency_stubs() -> None:
 
     const = sys.modules["homeassistant.const"]
     const.PERCENTAGE = "%"
-    const.EntityCategory = types.SimpleNamespace(DIAGNOSTIC="diagnostic")
+    const.EntityCategory = types.SimpleNamespace(DIAGNOSTIC="diagnostic", CONFIG="config")
     const.UnitOfTemperature = types.SimpleNamespace(CELSIUS="C")
 
     core = types.ModuleType("homeassistant.core")
@@ -172,7 +172,7 @@ def test_cellular_ip_sensors_are_enabled() -> None:
                 {"interface": "wan"},
                 {"interface": "modem_0001"},
             ]
-        }
+        },
     )
     assert _sensor_is_enabled(hub, desc_v4) is True
     assert _sensor_is_enabled(hub, desc_v6) is True
@@ -185,23 +185,21 @@ def test_cellular_ip_sensors_are_enabled() -> None:
                 {"interface": "wan"},
                 {"interface": "wwan"},
             ]
-        }
+        },
     )
     assert _sensor_is_enabled(hub, desc_v4) is False
     assert _sensor_is_enabled(hub, desc_v6) is False
 
     # Case 3: wan_status_monitors is configured, and modem_0001:ipv4 is selected
     hub = types.SimpleNamespace(
-        wan_status_monitors={"modem_0001:ipv4", "wan:ipv4"},
-        kmwan_status={}
+        wan_status_monitors={"modem_0001:ipv4", "wan:ipv4"}, kmwan_status={}
     )
     assert _sensor_is_enabled(hub, desc_v4) is True
     assert _sensor_is_enabled(hub, desc_v6) is False
 
     # Case 4: wan_status_monitors is configured, and modem_0001:ipv6 is selected
     hub = types.SimpleNamespace(
-        wan_status_monitors={"modem_0001:ipv6", "wwan:ipv4"},
-        kmwan_status={}
+        wan_status_monitors={"modem_0001:ipv6", "wwan:ipv4"}, kmwan_status={}
     )
     assert _sensor_is_enabled(hub, desc_v4) is False
     assert _sensor_is_enabled(hub, desc_v6) is True
@@ -253,5 +251,3 @@ def test_get_cellular_ip_resolves_correctly() -> None:
 
     assert _get_cellular_ip(hub, "ipv4") == "10.164.158.131"
     assert _get_cellular_ip(hub, "ipv6") == "2001:db8::1"
-
-

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -114,6 +114,7 @@ def test_wan_status_helpers_report_interface_protocol_state() -> None:
     assert sensor.extra_state_attributes == {
         "interface": "wan",
         "interface_name": "Ethernet 1",
+        "requested_interface": "wan",
         "monitored_protocols": ["ipv4", "ipv6"],
         "ipv4_status": "Up",
         "ipv6_status": "Down",
@@ -260,3 +261,176 @@ def test_get_cellular_ip_resolves_correctly() -> None:
 
     assert _get_cellular_ip(hub, "ipv4") == "10.164.158.131"
     assert _get_cellular_ip(hub, "ipv6") == "2001:db8::1"
+
+    # Case 3: 4.9 bodyless response puts ipv4/ipv6 at the top level of the
+    # modem object. The helper should still resolve them via the fallback
+    # path that bypasses the normalised ``network`` subdict.
+    hub = types.SimpleNamespace(
+        cellular_status={
+            "modems": [
+                {
+                    "bus": "0001:01:00.0",
+                    "network_interface": "modem_0001_s1",
+                    "ipv4": {
+                        "ip": "10.77.58.41",
+                        "gateway": "10.77.58.42",
+                        "netmask": "255.255.255.252",
+                    },
+                    "ipv6": {
+                        "ip": "2001:db8::42",
+                    },
+                }
+            ]
+        }
+    )
+
+    assert _get_cellular_ip(hub, "ipv4") == "10.77.58.41"
+    assert _get_cellular_ip(hub, "ipv6") == "2001:db8::42"
+
+
+def test_legacy_cellular_sensors_no_longer_registered() -> None:
+    from custom_components.glinet_router.entities.sensor import HUB_SENSORS
+
+    keys = {d.key for d in HUB_SENSORS}
+    assert "cellular_signal" not in keys
+    assert "cellular_rssi" not in keys
+    assert "cellular_network" not in keys
+    # ``cellular_band`` and the more granular signal measurements
+    # remain on every firmware version.
+    for expected in (
+        "cellular_band",
+        "cellular_rsrp",
+        "cellular_rsrq",
+        "cellular_sinr",
+        "cellular_apn",
+    ):
+        assert expected in keys
+
+
+def test_cellular_rsrp_remains_enabled_on_firmware_4_9() -> None:
+    from custom_components.glinet_router.entities.sensor import HUB_SENSORS, _sensor_is_enabled
+
+    desc_rsrp = next(d for d in HUB_SENSORS if d.key == "cellular_rsrp")
+    desc_band = next(d for d in HUB_SENSORS if d.key == "cellular_band")
+    desc_apn = next(d for d in HUB_SENSORS if d.key == "cellular_apn")
+
+    hub_49_enabled = types.SimpleNamespace(
+        wan_status_monitors=None,
+        kmwan_status={"interfaces": []},
+        is_firmware_4_9_or_above=True,
+        feature_enabled=lambda feature: True,
+    )
+    assert _sensor_is_enabled(hub_49_enabled, desc_rsrp) is True
+    assert _sensor_is_enabled(hub_49_enabled, desc_band) is True
+    assert _sensor_is_enabled(hub_49_enabled, desc_apn) is True
+
+    hub_49_disabled = types.SimpleNamespace(
+        wan_status_monitors=None,
+        kmwan_status={"interfaces": []},
+        is_firmware_4_9_or_above=True,
+        feature_enabled=lambda feature: False,
+    )
+    assert _sensor_is_enabled(hub_49_disabled, desc_rsrp) is False
+    assert _sensor_is_enabled(hub_49_disabled, desc_band) is False
+    assert _sensor_is_enabled(hub_49_disabled, desc_apn) is False
+
+
+def test_cellular_status_resolves_to_active_slot_on_firmware_4_9() -> None:
+    from custom_components.glinet_router.entities.sensor import (
+        WanStatusSensor,
+        _wan_interface_by_name,
+    )
+
+    hub = types.SimpleNamespace(
+        device_mac="00:11:22:33:44:55",
+        device_info={},
+        hass=object(),
+        is_firmware_4_9_or_above=True,
+        kmwan_status={
+            "interfaces": [
+                {"interface": "wan", "status_v4": 0, "status_v6": 1},
+                {"interface": "wwan", "status_v4": 1, "status_v6": 0},
+                # The aggregate the 4.9 router always reports as Down.
+                {"interface": "modem_0001", "status_v4": 1, "status_v6": 1},
+                # The real per-slot status — slot 1 is Up on IPv4.
+                {"interface": "modem_0001_s1", "status_v4": 0, "status_v6": 1},
+                {"interface": "modem_0001_s2", "status_v4": 1, "status_v6": 1},
+            ]
+        },
+    )
+
+    # The aggregate resolves to the active per-slot interface.
+    resolved = _wan_interface_by_name(hub, "modem_0001")
+    assert resolved is not None
+    assert resolved["interface"] == "modem_0001_s1"
+    assert resolved["status_v4"] == 0
+
+    # The sensor reports Up because the active slot is Up.
+    sensor = WanStatusSensor(hub, "modem_0001", {"ipv4", "ipv6"})
+    assert sensor.native_value == "Up"
+    attrs = sensor.extra_state_attributes
+    assert attrs["interface"] == "modem_0001_s1"
+    assert attrs["requested_interface"] == "modem_0001"
+    assert attrs["status_v4"] == 0
+    assert attrs["ipv4_status"] == "Up"
+    assert attrs["ipv6_status"] == "Down"
+
+
+def test_cellular_status_falls_back_to_first_slot_when_none_up_on_firmware_4_9() -> None:
+    from custom_components.glinet_router.entities.sensor import (
+        WanStatusSensor,
+        _wan_interface_by_name,
+    )
+
+    hub = types.SimpleNamespace(
+        device_mac="00:11:22:33:44:55",
+        device_info={},
+        hass=object(),
+        is_firmware_4_9_or_above=True,
+        kmwan_status={
+            "interfaces": [
+                {"interface": "modem_0001", "status_v4": 1, "status_v6": 1},
+                {"interface": "modem_0001_s1", "status_v4": 1, "status_v6": 1},
+                {"interface": "modem_0001_s2", "status_v4": 1, "status_v6": 1},
+            ]
+        },
+    )
+
+    resolved = _wan_interface_by_name(hub, "modem_0001")
+    assert resolved is not None
+    assert resolved["interface"] == "modem_0001_s1"
+
+    sensor = WanStatusSensor(hub, "modem_0001", {"ipv4", "ipv6"})
+    assert sensor.native_value == "Down"
+
+
+def test_cellular_status_keeps_aggregate_on_firmware_4_8() -> None:
+    from custom_components.glinet_router.entities.sensor import (
+        WanStatusSensor,
+        _wan_interface_by_name,
+    )
+
+    hub = types.SimpleNamespace(
+        device_mac="00:11:22:33:44:55",
+        device_info={},
+        hass=object(),
+        is_firmware_4_9_or_above=False,
+        kmwan_status={
+            "interfaces": [
+                {"interface": "modem_0001", "status_v4": 0, "status_v6": 1},
+            ]
+        },
+    )
+
+    resolved = _wan_interface_by_name(hub, "modem_0001")
+    assert resolved is not None
+    assert resolved["interface"] == "modem_0001"
+    assert resolved["status_v4"] == 0
+
+    sensor = WanStatusSensor(hub, "modem_0001", {"ipv4", "ipv6"})
+    assert sensor.native_value == "Up"
+    attrs = sensor.extra_state_attributes
+    # On 4.8 there's no fallback, so the resolved interface matches the
+    # requested one and ``requested_interface`` is informational only.
+    assert attrs["interface"] == "modem_0001"
+    assert attrs["requested_interface"] == "modem_0001"

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -8,6 +8,9 @@ from custom_components.glinet_router.utils import get_first_int, get_first_value
 
 
 def _install_sensor_dependency_stubs() -> None:
+    if _homeassistant_is_importable():
+        return
+
     @dataclass(frozen=True, kw_only=True)
     class SensorEntityDescription:
         key: str
@@ -40,7 +43,7 @@ def _install_sensor_dependency_stubs() -> None:
 
     const = sys.modules["homeassistant.const"]
     const.PERCENTAGE = "%"
-    const.EntityCategory = types.SimpleNamespace(DIAGNOSTIC="diagnostic")
+    const.EntityCategory = types.SimpleNamespace(DIAGNOSTIC="diagnostic", CONFIG="config")
     const.UnitOfTemperature = types.SimpleNamespace(CELSIUS="C")
 
     core = types.ModuleType("homeassistant.core")
@@ -51,6 +54,12 @@ def _install_sensor_dependency_stubs() -> None:
     entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
     entity_platform.AddEntitiesCallback = object
     sys.modules.setdefault("homeassistant.helpers.entity_platform", entity_platform)
+
+
+def _homeassistant_is_importable() -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec("homeassistant") is not None
 
 
 _install_sensor_dependency_stubs()

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -40,7 +40,7 @@ def _install_sensor_dependency_stubs() -> None:
 
     const = sys.modules["homeassistant.const"]
     const.PERCENTAGE = "%"
-    const.EntityCategory = types.SimpleNamespace(DIAGNOSTIC="diagnostic", CONFIG="config")
+    const.EntityCategory = types.SimpleNamespace(DIAGNOSTIC="diagnostic")
     const.UnitOfTemperature = types.SimpleNamespace(CELSIUS="C")
 
     core = types.ModuleType("homeassistant.core")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -61,6 +61,7 @@ from custom_components.glinet_router.const import (
     SERVICE_PARENTAL_CONTROL_SET_TEMPORARY_OVERRIDE,
     SERVICE_PARENTAL_CONTROL_UPDATE_SIGNATURES,
     SERVICE_PLAYGROUND,
+    SERVICE_REFRESH_CLIENTS,
     SERVICE_REFRESH_SMS,
     SERVICE_REMOVE_FIREWALL_RULE,
     SERVICE_REMOVE_PORT_FORWARD,
@@ -92,7 +93,6 @@ class DummyServices:
     def async_remove(self, domain: str, service: str) -> None:
         self.registrations = [(s, k) for s, k in self.registrations if s != service]
         self.handlers.pop(service, None)
-
 
 
 class DummyHass:
@@ -189,6 +189,7 @@ async def test_register_services_records_only_enabled_feature_services() -> None
         SERVICE_GET_SAVED_NETWORKS,
         SERVICE_REMOVE_SAVED_NETWORK,
         SERVICE_SET_FAN_TEMPERATURE,
+        SERVICE_REFRESH_CLIENTS,
     }
 
 
@@ -574,7 +575,9 @@ async def test_register_services_skips_disabled_features() -> None:
     await async_register_services(hass)
 
     assert hass.services.has_service(DOMAIN, SERVICE_SET_FAN_TEMPERATURE)
-    assert [s for s, _ in hass.services.registrations if s != SERVICE_SET_FAN_TEMPERATURE] == []
+    assert hass.services.has_service(DOMAIN, SERVICE_REFRESH_CLIENTS)
+    core_services = {SERVICE_SET_FAN_TEMPERATURE, SERVICE_REFRESH_CLIENTS}
+    assert [s for s, _ in hass.services.registrations if s not in core_services] == []
 
 
 async def test_repeater_scan_action_passes_refresh_flags() -> None:
@@ -730,3 +733,27 @@ async def test_playground_service_handler_calls_hub_method() -> None:
     assert calls == [("system/get_info", {"test": 1})]
     assert response == {"status": "ok"}
 
+
+async def test_refresh_clients_service_handler_calls_hub_methods() -> None:
+    calls: list[tuple[str, Any]] = []
+
+    class Hub:
+        device_mac = "00:11:22:33:44:55"
+
+        async def fetch_connected_devices(self) -> None:
+            calls.append(("fetch_connected_devices", None))
+
+        async def async_request_refresh(self) -> None:
+            calls.append(("async_request_refresh", None))
+
+    entry = DummyEntry()
+    entry.runtime_data = Hub()
+    hass = DummyHass([entry])
+    await async_register_services(hass)
+
+    await hass.services.handlers[SERVICE_REFRESH_CLIENTS](SimpleNamespace(data={}))
+
+    assert calls == [
+        ("fetch_connected_devices", None),
+        ("async_request_refresh", None),
+    ]

--- a/tests/test_vpn_tunnel.py
+++ b/tests/test_vpn_tunnel.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import types
+from typing import Any
+
+from custom_components.glinet_router.const import (
+    FEATURE_OVPN_CLIENT,
+    FEATURE_WG_CLIENT,
+)
+from custom_components.glinet_router.models import VpnTunnel, VpnTunnelType
+
+
+def test_vpn_tunnel_parses_wireguard_payload() -> None:
+    raw = {
+        "tunnel_id": 7488,
+        "name": "Tunnel 1",
+        "enabled": False,
+        "killswitch": True,
+        "via": {
+            "type": "wireguard",
+            "configs": [{"id_list": [2001], "group_id": 1543}],
+            "via": "wgclient1",
+        },
+    }
+    tunnel = VpnTunnel.from_api_response(raw)
+
+    assert tunnel.tunnel_id == 7488
+    assert tunnel.name == "Tunnel 1"
+    assert tunnel.tunnel_type == VpnTunnelType.WIREGUARD
+    assert tunnel.peer_id == 2001
+    assert tunnel.group_id == 1543
+    assert tunnel.client_id is None
+    assert tunnel.enabled is False
+    assert tunnel.killswitch is True
+    assert tunnel.via == "wgclient1"
+    assert tunnel.is_default is False
+
+
+def test_vpn_tunnel_parses_openvpn_payload() -> None:
+    raw = {
+        "tunnel_id": 1041,
+        "name": "Tunnel 2",
+        "enabled": True,
+        "killswitch": False,
+        "via": {
+            "type": "openvpn",
+            "configs": [{"id_list": [1], "group_id": 43568}],
+        },
+    }
+    tunnel = VpnTunnel.from_api_response(raw)
+
+    assert tunnel.tunnel_type == VpnTunnelType.OPENVPN
+    assert tunnel.client_id == 1
+    assert tunnel.group_id == 43568
+    assert tunnel.peer_id is None
+    assert tunnel.enabled is True
+    assert tunnel.is_default is False
+
+
+def test_vpn_tunnel_handles_unknown_type() -> None:
+    raw = {
+        "tunnel_id": 100,
+        "name": "Default",
+        "enabled": True,
+        "via": {"type": "default", "via": "novpn"},
+    }
+    tunnel = VpnTunnel.from_api_response(raw, is_default=True)
+
+    assert tunnel.tunnel_type == VpnTunnelType.UNKNOWN
+    assert tunnel.is_default is True
+    assert tunnel.peer_id is None
+    assert tunnel.client_id is None
+
+
+def test_vpn_tunnel_synthesises_default_name() -> None:
+    raw = {"tunnel_id": 555, "via": {"type": "wireguard"}}
+    tunnel = VpnTunnel.from_api_response(raw)
+
+    assert tunnel.tunnel_id == 555
+    assert tunnel.name == "Tunnel 555"
+
+
+def _make_hub() -> Any:
+    hub = types.SimpleNamespace()
+    hub._vpn_tunnels = {
+        7488: VpnTunnel(
+            tunnel_id=7488,
+            name="Tunnel 1",
+            tunnel_type=VpnTunnelType.WIREGUARD,
+            enabled=True,
+        ),
+        1041: VpnTunnel(
+            tunnel_id=1041,
+            name="Tunnel 2",
+            tunnel_type=VpnTunnelType.OPENVPN,
+            enabled=False,
+        ),
+        9999: VpnTunnel(
+            tunnel_id=9999,
+            name="Default",
+            tunnel_type=VpnTunnelType.UNKNOWN,
+            enabled=False,
+            is_default=True,
+        ),
+    }
+    return hub
+
+
+def test_vpn_tunnels_property_returns_dict() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._vpn_tunnels = _make_hub()._vpn_tunnels
+    hub._vpn_tunnel_connections = []
+
+    assert hub.vpn_tunnels[7488].tunnel_type == VpnTunnelType.WIREGUARD
+    assert hub.connected_vpn_tunnels == []
+
+
+def test_active_vpn_connections_includes_dashboard_tunnels() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._vpn_tunnels = _make_hub()._vpn_tunnels
+    hub._vpn_tunnel_connections = [hub._vpn_tunnels[7488]]
+    hub._wireguard_connections = []
+    hub._ovpn_connections = []
+
+    active = hub.active_vpn_connections
+    assert len(active) == 1
+    assert active[0].tunnel_id == 7488
+
+
+def test_feature_map_keywords_target_tunnel_unique_ids() -> None:
+    import inspect
+
+    from custom_components.glinet_router.hub import GLinetHub
+
+    source = inspect.getsource(GLinetHub.async_initialize_hub)
+    assert "vpn_tunnel/wg" in source
+    assert "vpn_tunnel/ovpn" in source
+    assert "vpn_tunnel/unknown" in source
+    # Sanity: feature flags exist.
+    assert FEATURE_WG_CLIENT
+    assert FEATURE_OVPN_CLIENT
+
+
+async def test_fetch_vpn_tunnels_routes_through_wg_client_submodule() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._vpn_tunnels = {}
+    hub._vpn_tunnel_connections = None
+
+    calls: list[str] = []
+
+    class _StubVpn:
+        async def get_tunnel(self) -> dict[str, Any]:
+            calls.append("get_tunnel")
+            return {"tunnels": [], "default_tunnels": []}
+
+        async def get_status(self) -> dict[str, Any]:
+            calls.append("get_status")
+            return {"status_list": []}
+
+    class _StubWgClient:
+        vpn_client = _StubVpn()
+
+    class _StubApi:
+        wg_client = _StubWgClient()
+        _firmware_version = (4, 9, 0, 0)
+
+        async def _is_firmware_at_least(self, version: tuple[int, int, int, int]) -> bool:
+            return self._firmware_version >= version
+
+    hub._api = _StubApi()
+
+    async def _invoke_optional(api_callable: Any) -> Any:
+        return await api_callable()
+
+    hub._invoke_optional_api = _invoke_optional
+
+    await hub.fetch_vpn_tunnels()
+
+    assert calls == ["get_tunnel", "get_status"]
+    assert hub._vpn_tunnels == {}
+    assert hub._vpn_tunnel_connections == []
+
+
+async def test_set_vpn_tunnel_uses_wg_client_vpn_client() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._vpn_tunnels = {}
+    hub._vpn_tunnel_connections = None
+
+    seen: dict[str, Any] = {}
+
+    class _StubVpn:
+        async def set_tunnel(self, tunnel_id: int, enabled: bool) -> dict[str, Any]:
+            seen["tunnel_id"] = tunnel_id
+            seen["enabled"] = enabled
+            return {"tunnel_id": tunnel_id}
+
+    class _StubWgClient:
+        vpn_client = _StubVpn()
+
+    class _StubApi:
+        wg_client = _StubWgClient()
+
+    hub._api = _StubApi()
+
+    async def _invoke(api_callable: Any) -> Any:
+        return await api_callable()
+
+    hub._invoke_api = _invoke
+    hub.fetch_vpn_tunnels = _async_noop
+    hub.fetch_wireguard_clients = _async_noop
+    hub.fetch_ovpn_clients = _async_noop
+
+    await hub.set_vpn_tunnel(1234, True)
+
+    assert seen == {"tunnel_id": 1234, "enabled": True}
+
+
+async def _async_noop(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+async def test_fetch_vpn_tunnels_handles_missing_vpn_client_submodule() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._vpn_tunnels = {"keep": "stale"}
+    hub._vpn_tunnel_connections = ["stale"]
+
+    class _StubApi:
+        wg_client = object()  # no vpn_client attribute
+
+    hub._api = _StubApi()
+
+    await hub.fetch_vpn_tunnels()
+
+    assert hub._vpn_tunnels == {}
+    assert hub._vpn_tunnel_connections == []
+
+
+async def test_fetch_vpn_tunnels_dispatches_update_event() -> None:
+    from custom_components.glinet_router.hub import GLinetHub
+
+    hub = GLinetHub.__new__(GLinetHub)
+    hub._vpn_tunnels = {}
+    hub._vpn_tunnel_connections = None
+    hub._factory_mac = "AA:BB:CC:DD:EE:FF"
+    hub.hass = object()
+
+    captured: dict[str, Any] = {}
+
+    def _capture(hass: Any, signal: str, payload: Any) -> None:
+        captured["signal"] = signal
+        captured["payload"] = payload
+
+    # Patch the module-level ``async_dispatcher_send`` used by hub.py.
+    import custom_components.glinet_router.hub as hub_module
+
+    original = hub_module.async_dispatcher_send
+    hub_module.async_dispatcher_send = _capture
+    try:
+        # Make a fake dashboard with a single WireGuard tunnel.
+        tunnel_payload = {
+            "tunnels": [
+                {
+                    "tunnel_id": 1,
+                    "name": "Tunnel 1",
+                    "enabled": False,
+                    "via": {
+                        "type": "wireguard",
+                        "configs": [{"id_list": [2001], "group_id": 1543}],
+                    },
+                }
+            ],
+            "default_tunnels": [],
+        }
+        status_payload = {"status_list": []}
+
+        class _StubVpn:
+            async def get_tunnel(self) -> dict[str, Any]:
+                return tunnel_payload
+
+            async def get_status(self) -> dict[str, Any]:
+                return status_payload
+
+        class _StubWgClient:
+            vpn_client = _StubVpn()
+
+        class _StubApi:
+            wg_client = _StubWgClient()
+            _firmware_version = (4, 9, 0, 0)
+
+            async def _is_firmware_at_least(self, version: tuple[int, int, int, int]) -> bool:
+                return self._firmware_version >= version
+
+        hub._api = _StubApi()
+
+        async def _invoke_optional(api_callable: Any) -> Any:
+            return await api_callable()
+
+        hub._invoke_optional_api = _invoke_optional
+
+        await hub.fetch_vpn_tunnels()
+
+        assert captured["signal"] == hub.event_vpn_tunnels_updated
+        assert captured["payload"] == {1}
+    finally:
+        hub_module.async_dispatcher_send = original
+
+
+def test_reconcile_vpn_tunnels_removes_stale_switches() -> None:
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    removed_states: list[Any] = []
+    removed_registry: list[str] = []
+
+    class _StubRegistry:
+        def __init__(self) -> None:
+            self.async_remove = self._remove
+
+        def _remove(self, entity_id: str) -> None:
+            removed_registry.append(entity_id)
+
+    class _StubEntity:
+        def __init__(self, tunnel_id: int, entity_id: str) -> None:
+            self._tunnel_id = tunnel_id
+            self.entity_id = entity_id
+            # ``async_remove`` is a coroutine on the real entity; the
+            # AsyncMock makes the call awaitable so the test mirrors the
+            # production behaviour and surfaces a warning if it is not
+            # awaited.
+            self.async_remove = AsyncMock(
+                side_effect=lambda *, force_remove=False: removed_states.append(
+                    (self._tunnel_id, self.entity_id, force_remove)
+                )
+            )
+
+    stub_hub = types.SimpleNamespace()
+    stub_hub.vpn_tunnels = {
+        1: types.SimpleNamespace(
+            tunnel_id=1,
+            tunnel_type=VpnTunnelType.WIREGUARD,
+            name="t1",
+        ),
+        2: types.SimpleNamespace(
+            tunnel_id=2,
+            tunnel_type=VpnTunnelType.OPENVPN,
+            name="t2",
+        ),
+    }
+
+    def _feature_enabled(feature: str) -> bool:
+        return feature in {FEATURE_WG_CLIENT, FEATURE_OVPN_CLIENT}
+
+    stub_hub.feature_enabled = _feature_enabled
+
+    class _StubVpnTunnelSwitch:
+
+        def __init__(self, hub: Any, tunnel: Any, entity_id: str) -> None:
+            self._tunnel_id = tunnel.tunnel_id
+            self._hub = hub
+            self._tunnel = tunnel
+            self.entity_id = entity_id
+            self.async_remove = AsyncMock()
+
+    # Build the registry the same way async_setup_entry does.
+    entities = [
+        _StubVpnTunnelSwitch(
+            stub_hub, stub_hub.vpn_tunnels[1], "switch.tunnel_1"
+        ),
+        _StubVpnTunnelSwitch(
+            stub_hub, stub_hub.vpn_tunnels[2], "switch.tunnel_2"
+        ),
+    ]
+    vpn_tunnel_switches: dict[int, Any] = {
+        entity._tunnel_id: entity for entity in entities
+    }
+    registry = _StubRegistry()
+
+    # Simulate the router reporting only tunnel 1 (tunnel 2 was removed).
+    current_ids = {1}
+
+    # Inline the reconcile body (matches the implementation in switch.py)
+    # and ``await`` async_remove just like the real platform does.
+    async def _run_reconcile() -> None:
+        existing_ids = set(vpn_tunnel_switches.keys())
+        stale_ids = existing_ids - current_ids
+        for stale_id in list(stale_ids):
+            entity = vpn_tunnel_switches.pop(stale_id, None)
+            if entity is None:
+                continue
+            # ``await`` is required for ``Entity.async_remove`` to
+            # actually run on the real platform.
+            await entity.async_remove(force_remove=True)
+            if entity.entity_id:
+                registry.async_remove(entity.entity_id)
+
+    asyncio.run(_run_reconcile())
+
+    # The state-removal coroutine ran and was awaited.
+    assert (2, "switch.tunnel_2", True) in removed_states
+    # The registry entry was also removed so the entity fully disappears.
+    assert "switch.tunnel_2" in removed_registry
+    # Tunnel 1 was not touched.
+    assert 2 not in vpn_tunnel_switches
+    assert 1 in vpn_tunnel_switches
+    # Every entity.async_remove call must have been awaited.
+    for entity in entities:
+        entity.async_remove.assert_awaited()

--- a/tests/test_vpn_tunnel.py
+++ b/tests/test_vpn_tunnel.py
@@ -363,7 +363,6 @@ def test_reconcile_vpn_tunnels_removes_stale_switches() -> None:
     stub_hub.feature_enabled = _feature_enabled
 
     class _StubVpnTunnelSwitch:
-
         def __init__(self, hub: Any, tunnel: Any, entity_id: str) -> None:
             self._tunnel_id = tunnel.tunnel_id
             self._hub = hub
@@ -373,16 +372,10 @@ def test_reconcile_vpn_tunnels_removes_stale_switches() -> None:
 
     # Build the registry the same way async_setup_entry does.
     entities = [
-        _StubVpnTunnelSwitch(
-            stub_hub, stub_hub.vpn_tunnels[1], "switch.tunnel_1"
-        ),
-        _StubVpnTunnelSwitch(
-            stub_hub, stub_hub.vpn_tunnels[2], "switch.tunnel_2"
-        ),
+        _StubVpnTunnelSwitch(stub_hub, stub_hub.vpn_tunnels[1], "switch.tunnel_1"),
+        _StubVpnTunnelSwitch(stub_hub, stub_hub.vpn_tunnels[2], "switch.tunnel_2"),
     ]
-    vpn_tunnel_switches: dict[int, Any] = {
-        entity._tunnel_id: entity for entity in entities
-    }
+    vpn_tunnel_switches: dict[int, Any] = {entity._tunnel_id: entity for entity in entities}
     registry = _StubRegistry()
 
     # Simulate the router reporting only tunnel 1 (tunnel 2 was removed).

--- a/tests/test_wg_client_firmware.py
+++ b/tests/test_wg_client_firmware.py
@@ -143,3 +143,58 @@ async def test_future_versions_keep_using_4_9_peer_payload(
             "peer_id": 2001,
         },
     ]
+
+
+async def test_wg_vpn_client_exposes_get_tunnel() -> None:
+    from custom_components.glinet_router.api.modules.wg_client import (
+        VpnClientModule as WgVpnClientModule,
+    )
+
+    assert hasattr(WgVpnClientModule, "get_tunnel")
+    assert hasattr(WgVpnClientModule, "get_status")
+    assert hasattr(WgVpnClientModule, "set_tunnel")
+
+    client = _make_client(
+        [{"result": {"tunnels": [], "default_tunnels": []}}], FIRMWARE_4_9
+    )
+    response = await client.wg_client.vpn_client.get_tunnel()
+
+    assert response == {"tunnels": [], "default_tunnels": []}
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "get_tunnel",
+        {},
+    ]
+
+
+async def test_wg_vpn_client_get_tunnel_falls_back_on_legacy_firmware() -> None:
+    from custom_components.glinet_router.api.exceptions import NonZeroResponse
+
+    class _BoomSession(FakeSession):
+        def __init__(self) -> None:
+            super().__init__([])
+
+        def post(self, url: str, json: dict[str, Any], timeout: int):  # type: ignore[override]
+            from tests.test_api_client import FakePostContext, FakeResponse
+
+            return FakePostContext(
+                FakeResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32001, "message": "unsupported"},
+                    }
+                )
+            )
+
+    session = _BoomSession()
+    client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
+    client._firmware_version = FIRMWARE_4_8
+
+    response = await client.wg_client.vpn_client.get_tunnel()
+
+    assert response == {"tunnels": [], "default_tunnels": []}
+    # The raised NonZeroResponse must not propagate to the caller.
+    assert isinstance(
+        NonZeroResponse.__mro__[0], type
+    )  # keeps the import alive for static analysis

--- a/tests/test_wg_client_firmware.py
+++ b/tests/test_wg_client_firmware.py
@@ -1,0 +1,145 @@
+from typing import Any
+
+import pytest
+
+from custom_components.glinet_router.api.client import GLinetApiClient
+from custom_components.glinet_router.api.const import FIRMWARE_4_8, FIRMWARE_4_9
+from tests.test_api_client import FakeSession
+
+
+def _make_client(responses: list[Any], version: tuple[int, int, int, int]) -> GLinetApiClient:
+    session = FakeSession(responses)
+    client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
+    client._firmware_version = version
+    return client
+
+
+async def test_set_tunnel_by_peer_emits_4_9_payload() -> None:
+    client = _make_client([{"result": []}], FIRMWARE_4_9)
+
+    await client.wg_client.vpn_client.set_tunnel_by_peer(
+        enabled=True,
+        tunnel_type="wireguard",
+        group_id=1543,
+        peer_id=2001,
+    )
+
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
+        {
+            "enabled": True,
+            "type": "wireguard",
+            "group_id": 1543,
+            "peer_id": 2001,
+        },
+    ]
+
+
+async def test_set_tunnel_by_peer_includes_tunnel_id_when_provided() -> None:
+    client = _make_client([{"result": []}], FIRMWARE_4_9)
+
+    await client.wg_client.vpn_client.set_tunnel_by_peer(
+        enabled=False,
+        tunnel_type="wireguard",
+        group_id=1543,
+        peer_id=2001,
+        tunnel_id=8040,
+    )
+
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
+        {
+            "enabled": False,
+            "type": "wireguard",
+            "group_id": 1543,
+            "peer_id": 2001,
+            "tunnel_id": 8040,
+        },
+    ]
+
+
+async def test_start_wireguard_client_uses_peer_payload_on_4_9() -> None:
+    client = _make_client([{"result": []}], FIRMWARE_4_9)
+
+    await client.wg_client.start_wireguard_client(group_id=1543, peer_id=2001)
+
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
+        {
+            "enabled": True,
+            "type": "wireguard",
+            "group_id": 1543,
+            "peer_id": 2001,
+        },
+    ]
+
+
+async def test_stop_wireguard_client_uses_peer_payload_on_4_9() -> None:
+    client = _make_client([{"result": []}], FIRMWARE_4_9)
+
+    await client.wg_client.stop_wireguard_client(group_id=1543, peer_id=2001)
+
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
+        {
+            "enabled": False,
+            "type": "wireguard",
+            "group_id": 1543,
+            "peer_id": 2001,
+        },
+    ]
+
+
+async def test_start_wireguard_client_uses_set_tunnel_on_4_8() -> None:
+    client = _make_client([{"result": {"ok": True}}], FIRMWARE_4_8)
+
+    await client.wg_client.start_wireguard_client(group_id=1543, peer_id=2001)
+
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
+        {"enabled": True, "tunnel_id": 2001},
+    ]
+
+
+async def test_stop_wireguard_client_uses_set_tunnel_on_4_8() -> None:
+    client = _make_client([{"result": {"ok": True}}], FIRMWARE_4_8)
+
+    await client.wg_client.stop_wireguard_client(group_id=1543, peer_id=2001)
+
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
+        {"enabled": False, "tunnel_id": 2001},
+    ]
+
+
+@pytest.mark.parametrize("future_version", [(4, 10, 0, 0), (5, 0, 0, 0), (5, 1, 3, 0)])
+async def test_future_versions_keep_using_4_9_peer_payload(
+    future_version: tuple[int, int, int, int],
+) -> None:
+    client = _make_client([{"result": []}], future_version)
+
+    await client.wg_client.start_wireguard_client(group_id=1543, peer_id=2001)
+
+    assert client._session.requests[0]["json"]["params"] == [
+        "sid-1",
+        "vpn-client",
+        "set_tunnel",
+        {
+            "enabled": True,
+            "type": "wireguard",
+            "group_id": 1543,
+            "peer_id": 2001,
+        },
+    ]

--- a/tests/test_wg_client_firmware.py
+++ b/tests/test_wg_client_firmware.py
@@ -154,9 +154,7 @@ async def test_wg_vpn_client_exposes_get_tunnel() -> None:
     assert hasattr(WgVpnClientModule, "get_status")
     assert hasattr(WgVpnClientModule, "set_tunnel")
 
-    client = _make_client(
-        [{"result": {"tunnels": [], "default_tunnels": []}}], FIRMWARE_4_9
-    )
+    client = _make_client([{"result": {"tunnels": [], "default_tunnels": []}}], FIRMWARE_4_9)
     response = await client.wg_client.vpn_client.get_tunnel()
 
     assert response == {"tunnels": [], "default_tunnels": []}

--- a/tests/test_wg_server.py
+++ b/tests/test_wg_server.py
@@ -16,50 +16,46 @@ def wg_server_status_response() -> dict[str, Any]:
                 "log": "",
                 "tunnel_ip": "10.0.0.1/24",
                 "rx_bytes": 1000,
-                "tx_bytes": 2000
+                "tx_bytes": 2000,
             },
             "peers": [
-                {
-                    "name": "peer1",
-                    "status": 1,
-                    "peer_id": 1
-                },
-                {
-                    "name": "peer2",
-                    "status": 0,
-                    "peer_id": 2
-                }
-            ]
+                {"name": "peer1", "status": 1, "peer_id": 1},
+                {"name": "peer2", "status": 0, "peer_id": 2},
+            ],
         }
     }
+
 
 async def test_wg_server_get_status(wg_server_status_response: dict[str, Any]) -> None:
     session = FakeSession([wg_server_status_response])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     status = await client.wg_server.get_status()
     assert status["server"]["status"] == 1
     assert len(status["peers"]) == 2
     assert session.requests[0]["json"]["params"] == ["sid-1", "wg-server", "get_status", {}]
 
+
 async def test_wg_server_start() -> None:
     session = FakeSession([{"result": {"ok": True}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     await client.wg_server.start()
     assert session.requests[0]["json"]["params"] == ["sid-1", "wg-server", "start", {}]
+
 
 async def test_wg_server_stop() -> None:
     session = FakeSession([{"result": {"ok": True}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     await client.wg_server.stop()
     assert session.requests[0]["json"]["params"] == ["sid-1", "wg-server", "stop", {}]
+
 
 async def test_wg_server_get_peer_list() -> None:
     session = FakeSession([{"result": {"peers": [{"name": "p1"}]}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     peers = await client.wg_server.get_peer_list()
     assert len(peers) == 1
     assert peers[0]["name"] == "p1"

--- a/tests/test_zerotier.py
+++ b/tests/test_zerotier.py
@@ -8,14 +8,8 @@ from tests.test_api_client import FakeSession
 
 @pytest.fixture
 def zerotier_config_response() -> dict[str, Any]:
-    return {
-        "result": {
-            "id": "12345678",
-            "enable": True,
-            "lan_enabled": True,
-            "wan_enabled": False
-        }
-    }
+    return {"result": {"id": "12345678", "enable": True, "lan_enabled": True, "wan_enabled": False}}
+
 
 @pytest.fixture
 def zerotier_status_response() -> dict[str, Any]:
@@ -24,30 +18,33 @@ def zerotier_status_response() -> dict[str, Any]:
             "status": 0,
             "zerotier_ip": "10.147.17.1",
             "lan_ip": "192.168.8.0/24",
-            "wan_ip": "1.1.1.1"
+            "wan_ip": "1.1.1.1",
         }
     }
+
 
 async def test_zerotier_get_config(zerotier_config_response: dict[str, Any]) -> None:
     session = FakeSession([zerotier_config_response])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     config = await client.zerotier.get_config()
     assert config["id"] == "12345678"
     assert config["enable"] is True
 
+
 async def test_zerotier_get_status(zerotier_status_response: dict[str, Any]) -> None:
     session = FakeSession([zerotier_status_response])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     status = await client.zerotier.get_status()
     assert status["status"] == 0
     assert status["zerotier_ip"] == "10.147.17.1"
 
+
 async def test_zerotier_set_config() -> None:
     session = FakeSession([{"result": {"ok": True}}])
     client = GLinetApiClient("http://router/rpc", session, sid="sid-1")
-    
+
     params = {"enabled": True, "id": "12345678"}
     await client.zerotier.set_config(params)
     expected_params = ["sid-1", "zerotier", "set_config", params]


### PR DESCRIPTION
Refactor: 
- Wireguard and OpenVPN have been re-pointed to pull data from VPN Dashboard on 4.9 firmware
- My initial cellular support for 4.9.0 was broken in several places due to some discrepancies in reference documentation. This has been fixed with full reverse compatibility for 4.8.0
- SMS functionality is now supported in 4.9.0 and is fully backwards compatible. 

Features: 
- Added capability to turn on synchronous requests to the router. This will be a performance improvement for new routers. Older routers should maintain asynchronous if they encounter issues. 

Housekeeping: 
- Completely forgot ruff had a format function. Running this caused a fairly big cleanup of files thus the large diff size. 
- Docs and README still contained old URL for wiki and docs which causes breaks for pages. 
- Split the docs to make the information more concise per page rather than have multiple methods being covered in a single place.

Breaking: 
- Cellular RSSI & Cellular Signal no longer existing in 4.9.0. These sensors have been removed.

ToCheck: 
- [x] Cellular
- [ ] Repeater
- [x] SMS
- [ ] Tailscale
- [ ] Wireguard Server
- [x] Wireguard Client
- [x] OpenVPN Client
- [ ] OpenVPN Server
- [ ] AdGuard Home
- [ ] Firewall
- [ ] MCU Battery
- [ ] MCU OLED
- [ ] Parental & Access Control
- [x] Playground
- [x] Cellular WAN Sensors
- [ ] Ethernet WAN Sensors
- [ ] Repeater WAN Sensors
- [ ] Tethering WAN Sensors