### PR TITLE
feat: Add verify_ssl option to support self-signed certificates

### DIFF
--- a/custom_components/glinet_router/api/client.py
+++ b/custom_components/glinet_router/api/client.py
@@ -92,8 +92,10 @@ class GLinetApiClient:
         base_url: str,
         session: ClientSession,
         sid: str | None = None,
+        verify_ssl: bool = True
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        self._ssl_setting = None if verify_ssl else False
         self._session = session
         self.sid = sid
         self._logged_in = sid is not None
@@ -148,6 +150,7 @@ class GLinetApiClient:
             self._base_url,
             json=payload,
             timeout=timeout_seconds,
+            ssl=self._ssl_setting
         ) as response:
             return await _extract_response_data(response)
 

--- a/custom_components/glinet_router/api/client.py
+++ b/custom_components/glinet_router/api/client.py
@@ -92,7 +92,7 @@ class GLinetApiClient:
         base_url: str,
         session: ClientSession,
         sid: str | None = None,
-        verify_ssl: bool = True
+        verify_ssl: bool = False
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._ssl_setting = None if verify_ssl else False

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -256,7 +256,6 @@ class SetupHub:
         self.router_mac = ""
         self.router_model = ""
         self.wan_interfaces: list[str] = DEFAULT_WAN_INTERFACES
-        self.verify_ssl = verify_ssl
 
     async def check_reachable(self) -> bool:
         try:

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -239,7 +239,9 @@ STEP_USER_DATA_SCHEMA = _config_schema()
 
 class SetupHub:
 
-    def __init__(self, host: str, hass: HomeAssistant, verify_ssl: book = True) -> None:
+    def __init__(
+        self, host: str, hass: HomeAssistant, verify_ssl: book = True
+    ) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
         self.router = GLinetApiClient(

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -153,7 +153,7 @@ def _config_schema(
         vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
-        vol.Required(CONF_VERIFY_SSL, default=True): bool,
+        vol.Required(CONF_VERIFY_SSL, default=False): bool,
         vol.Optional(
             CONF_PARALLEL_REQUESTS,
             default=defaults.get(CONF_PARALLEL_REQUESTS, DEFAULT_PARALLEL_REQUESTS),
@@ -244,7 +244,7 @@ STEP_USER_DATA_SCHEMA = _config_schema()
 class SetupHub:
 
     def __init__(
-        self, host: str, hass: HomeAssistant, verify_ssl: bool = True
+        self, host: str, hass: HomeAssistant, verify_ssl: bool = False
     ) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
@@ -295,7 +295,7 @@ class SetupHub:
 async def process_user_input(
     data: dict[str, Any], hass: HomeAssistant, raise_on_invalid_auth: bool = True
 ) -> dict[str, Any]:
-    verify_ssl_choice = data.get(CONF_VERIFY_SSL, True)
+    verify_ssl_choice = data.get(CONF_VERIFY_SSL, False)
     hub = SetupHub(data[CONF_HOST], hass, verify_ssl=verify_ssl_choice)
     if not await hub.check_reachable():
         raise CannotConnect

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -240,7 +240,7 @@ STEP_USER_DATA_SCHEMA = _config_schema()
 class SetupHub:
 
     def __init__(
-        self, host: str, hass: HomeAssistant, verify_ssl: book = True
+        self, host: str, hass: HomeAssistant, verify_ssl: bool = True
     ) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_UNKNOWN_DEVICES_FILTER_MANUAL,
     CONF_UNKNOWN_DEVICES_FILTER_MODE,
     CONF_UNKNOWN_DEVICES_FILTER_SELECT,
+    CONF_VERIFY_SSL,
     CONF_WAN_STATUS_MONITORS,
     DEFAULT_PASSWORD,
     DEFAULT_UNKNOWN_DEVICES_FILTER_MODE,
@@ -152,6 +153,7 @@ def _config_schema(
         vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
+        vol.Required(CONF_VERIFY_SSL, default=True): bool,
         vol.Optional(
             CONF_CONSIDER_HOME,
             default=DEFAULT_CONSIDER_HOME.total_seconds(),
@@ -237,16 +239,18 @@ STEP_USER_DATA_SCHEMA = _config_schema()
 
 class SetupHub:
 
-    def __init__(self, host: str, hass: HomeAssistant) -> None:
+    def __init__(self, host: str, hass: HomeAssistant, verify_ssl: book = True) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
         self.router = GLinetApiClient(
             base_url=f"{host}{API_PATH}",
             session=async_get_clientsession(hass),
+            verify_ssl=verify_ssl,
         )
         self.router_mac = ""
         self.router_model = ""
         self.wan_interfaces: list[str] = DEFAULT_WAN_INTERFACES
+        self.verify_ssl = verify_ssl
 
     async def check_reachable(self) -> bool:
         try:
@@ -286,7 +290,8 @@ class SetupHub:
 async def process_user_input(
     data: dict[str, Any], hass: HomeAssistant, raise_on_invalid_auth: bool = True
 ) -> dict[str, Any]:
-    hub = SetupHub(data[CONF_HOST], hass)
+    verify_ssl_choice = data.get(CONF_VERIFY_SSL, True)
+    hub = SetupHub(data[CONF_HOST], hass, verify_ssl=verify_ssl_choice)
     if not await hub.check_reachable():
         raise CannotConnect
 
@@ -304,6 +309,7 @@ async def process_user_input(
             CONF_USERNAME: DEFAULT_USERNAME,
             CONF_HOST: data[CONF_HOST],
             CONF_PASSWORD: data.get(CONF_PASSWORD, DEFAULT_PASSWORD) if valid_auth else "",
+            CONF_VERIFY_SSL: verify_ssl_choice,
             CONF_CONSIDER_HOME: data.get(
                 CONF_CONSIDER_HOME,
                 DEFAULT_CONSIDER_HOME.total_seconds(),

--- a/custom_components/glinet_router/config_flow.py
+++ b/custom_components/glinet_router/config_flow.py
@@ -246,7 +246,6 @@ class SetupHub:
     def __init__(
         self, host: str, hass: HomeAssistant, verify_ssl: bool = True
     ) -> None:
-    def __init__(self, host: str, hass: HomeAssistant) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
         self.router = GLinetApiClient(

--- a/custom_components/glinet_router/const.py
+++ b/custom_components/glinet_router/const.py
@@ -13,6 +13,7 @@ CONF_WAN_STATUS_MONITORS = "wan_status_monitors"
 CONF_UNKNOWN_DEVICES_FILTER_MODE = "unknown_devices_filter_mode"
 CONF_UNKNOWN_DEVICES_FILTER_SELECT = "unknown_devices_filter_select"
 CONF_UNKNOWN_DEVICES_FILTER_MANUAL = "unknown_devices_filter_manual"
+CONF_VERIFY_SSL = "verify_ssl"
 DEFAULT_UNKNOWN_DEVICES_FILTER_MODE = "blacklist"
 
 WAN_INTERFACE_NAMES = {

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -351,7 +351,9 @@ class GLinetHub(DataUpdateCoordinator[None]):
     def _create_api_client(self) -> GLinetApiClient:
         session = async_get_clientsession(self.hass)
         verify_ssl = self._settings.get(CONF_VERIFY_SSL, True)
-        return GLinetApiClient(base_url=f"{self._host}{API_PATH}", session=session, verify_ssl=verify_ssl)
+        return GLinetApiClient(
+            base_url=f"{self._host}{API_PATH}", session=session, verify_ssl=verify_ssl
+        )
 
     async def _async_load_router_info(self) -> None:
         try:

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -384,7 +384,7 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
     def _create_api_client(self) -> GLinetApiClient:
         session = async_get_clientsession(self.hass)
-        verify_ssl = self._settings.get(CONF_VERIFY_SSL, True)
+        verify_ssl = self._settings.get(CONF_VERIFY_SSL, False)
         return GLinetApiClient(
             base_url=f"{self._host}{API_PATH}", session=session, verify_ssl=verify_ssl
         )

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_USERNAME,
-    CONF_VERIFY_SSL,
 )
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -46,6 +45,7 @@ from .const import (
     CONF_UNKNOWN_DEVICES_FILTER_MANUAL,
     CONF_UNKNOWN_DEVICES_FILTER_MODE,
     CONF_UNKNOWN_DEVICES_FILTER_SELECT,
+    CONF_VERIFY_SSL,
     CONF_WAN_STATUS_MONITORS,
     DEFAULT_USERNAME,
     DOMAIN,

--- a/custom_components/glinet_router/hub.py
+++ b/custom_components/glinet_router/hub.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
 )
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -349,7 +350,8 @@ class GLinetHub(DataUpdateCoordinator[None]):
 
     def _create_api_client(self) -> GLinetApiClient:
         session = async_get_clientsession(self.hass)
-        return GLinetApiClient(base_url=f"{self._host}{API_PATH}", session=session)
+        verify_ssl = self._settings.get(CONF_VERIFY_SSL, True)
+        return GLinetApiClient(base_url=f"{self._host}{API_PATH}", session=session, verify_ssl=verify_ssl)
 
     async def _async_load_router_info(self) -> None:
         try:

--- a/custom_components/glinet_router/strings.json
+++ b/custom_components/glinet_router/strings.json
@@ -7,7 +7,7 @@
         "data": {
           "host": "Router Address",
           "password": "Admin Password",
-	  "verify_ssl": "Verify SSL Certificate",
+          "verify_ssl": "Verify SSL Certificate",
           "consider_home": "Away Delay",
           "scan_interval": "Update Interval",
           "enabled_features": "Enabled features",
@@ -21,7 +21,7 @@
         "data_description": {
           "host": "Use the router URL or IP address (for example: http://192.168.8.1).",
           "password": "Provide the same password you use for the router admin interface.",
-          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
+          "verify_ssl": "Validate the router's TLS certificate. Enable this only if your router uses a valid certificate.",
           "consider_home": "Set how many seconds a client can be offline before it is marked away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",
@@ -63,7 +63,7 @@
         "data_description": {
           "host": "Use the router URL or IP address (for example: http://192.168.8.1).",
           "password": "Provide the same password you use for the router admin interface.",
-          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
+          "verify_ssl": "Validate the router's TLS certificate. Enable this only if your router uses a valid certificate.",
           "consider_home": "Set how many seconds a client can be offline before it is marked away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",

--- a/custom_components/glinet_router/strings.json
+++ b/custom_components/glinet_router/strings.json
@@ -7,6 +7,7 @@
         "data": {
           "host": "Router Address",
           "password": "Admin Password",
+	  "verify_ssl": "Verify SSL Certificate",
           "consider_home": "Away Delay",
           "scan_interval": "Update Interval",
           "enabled_features": "Enabled features",

--- a/custom_components/glinet_router/strings.json
+++ b/custom_components/glinet_router/strings.json
@@ -49,6 +49,7 @@
         "data": {
           "host": "Router Address",
           "password": "Admin Password",
+          "verify_ssl": "Verify SSL Certificate",
           "consider_home": "Away Delay",
           "scan_interval": "Update Interval",
           "enabled_features": "Enabled features",

--- a/custom_components/glinet_router/strings.json
+++ b/custom_components/glinet_router/strings.json
@@ -21,6 +21,7 @@
         "data_description": {
           "host": "Use the router URL or IP address (for example: http://192.168.8.1).",
           "password": "Provide the same password you use for the router admin interface.",
+          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
           "consider_home": "Set how many seconds a client can be offline before it is marked away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",
@@ -61,6 +62,7 @@
         "data_description": {
           "host": "Use the router URL or IP address (for example: http://192.168.8.1).",
           "password": "Provide the same password you use for the router admin interface.",
+          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
           "consider_home": "Set how many seconds a client can be offline before it is marked away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",

--- a/custom_components/glinet_router/translations/en.json
+++ b/custom_components/glinet_router/translations/en.json
@@ -7,6 +7,7 @@
         "data": {
           "host": "Router Address",
           "password": "Admin Password",
+	  "verify_ssl": "Verify SSL Certificate",
           "consider_home": "Away Delay",
           "scan_interval": "Update Interval",
           "enabled_features": "Enabled features",

--- a/custom_components/glinet_router/translations/en.json
+++ b/custom_components/glinet_router/translations/en.json
@@ -22,6 +22,7 @@
         "data_description": {
           "host": "Type the router hostname, URL, or IP address.",
           "password": "Enter the admin password configured on your GL.iNet router.",
+          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
           "consider_home": "Number of seconds before a disconnected client is treated as away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",
@@ -64,6 +65,7 @@
         "data_description": {
           "host": "Type the router hostname, URL, or IP address.",
           "password": "Enter the admin password configured on your GL.iNet router.",
+          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
           "consider_home": "Number of seconds before a disconnected client is treated as away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",

--- a/custom_components/glinet_router/translations/en.json
+++ b/custom_components/glinet_router/translations/en.json
@@ -51,6 +51,7 @@
         "data": {
           "host": "Router Address",
           "password": "Admin Password",
+          "verify_ssl": "Verify SSL Certificate",
           "consider_home": "Away Delay",
           "scan_interval": "Update Interval",
           "enabled_features": "Enabled features",

--- a/custom_components/glinet_router/translations/en.json
+++ b/custom_components/glinet_router/translations/en.json
@@ -7,7 +7,7 @@
         "data": {
           "host": "Router Address",
           "password": "Admin Password",
-	  "verify_ssl": "Verify SSL Certificate",
+          "verify_ssl": "Verify SSL Certificate",
           "consider_home": "Away Delay",
           "scan_interval": "Update Interval",
           "enabled_features": "Enabled features",
@@ -22,7 +22,7 @@
         "data_description": {
           "host": "Type the router hostname, URL, or IP address.",
           "password": "Enter the admin password configured on your GL.iNet router.",
-          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
+          "verify_ssl": "Validate the router's TLS certificate. Enable this only if your router uses a valid certificate.",
           "consider_home": "Number of seconds before a disconnected client is treated as away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",
@@ -66,7 +66,7 @@
         "data_description": {
           "host": "Type the router hostname, URL, or IP address.",
           "password": "Enter the admin password configured on your GL.iNet router.",
-          "verify_ssl": "Validate the router's TLS certificate. Disable this if your router uses a self-signed certificate (common on stock GL.iNet firmware). Disabling verification reduces security on your local network.",
+          "verify_ssl": "Validate the router's TLS certificate. Enable this only if your router uses a valid certificate.",
           "consider_home": "Number of seconds before a disconnected client is treated as away.",
           "scan_interval": "Number of seconds between polling the router for updates.",
           "enabled_features": "Choose the integration feature groups to set up. Disabled feature groups will not create their related entities or services.",

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -85,6 +85,7 @@ These pages cover what the integration provides, how to configure it, and how to
 - [Automation Templates](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/automations) - Ready-made automations you can paste into Home Assistant.
 - [Smart Fan](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/smart-fan) - Fan status, speed, and temperature threshold controls.
 - [Unknown Device Management](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/unknown-devices) - Discovery, cleanup, and allow/blocklist handling for unknown devices.
+- [SSL Verification](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/ssl-verification) - Manage TLS certificate validation for self-signed router certificates.
 - [Refresh Clients](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/refresh-clients) - Force a client list refresh outside the normal polling cycle.
 - [Targeting a Specific Router](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/router-targeting) - Use the optional `mac` parameter to address a single router.
 - [Triggers](https://github.com/vithurshanselvarajah/ha-glinet-router/wiki/triggers) - Building automations that react to GL.iNet router state.

--- a/docs/ssl-verification.md
+++ b/docs/ssl-verification.md
@@ -1,0 +1,30 @@
+# SSL Certificate Verification
+
+The integration skips TLS certificate verification of your GL.iNet router on
+every connection. Verification is **off by default** because most GL.iNet
+routers ship with a self-signed certificate that fails strict validation.
+
+## When to enable it
+
+Enable **Verify SSL Certificate** in the config or options form if your
+router uses a trusted certificate — for example, one issued by a private CA
+on your network or by a public CA such as Let's Encrypt.
+
+## What it does
+
+- **Disabled (default)** — Certificate validation is skipped. Any TLS
+  certificate is accepted, including the stock GL.iNet self-signed certificate.
+  This is functionally equivalent to clicking through a browser's "your
+  connection is not private" warning. The setting only affects traffic to
+  your own router on your local network.
+- **Enabled** — HTTPS requests validate the certificate against the system
+  trust store. Self-signed, expired, or mismatched certificates cause the
+  connection to fail.
+
+## Changing the setting
+
+1. **Settings → Devices & Services → GL.iNet Router → Configure**.
+2. Toggle **Verify SSL Certificate**.
+3. Submit. The options form re-runs the connection test and full login before
+   saving, so a broken setting will surface as a `cannot_connect` error
+   instead of being persisted.

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -637,3 +637,33 @@ async def test_custom_call_sends_expected_payloads() -> None:
             "id": 0,
         },
     ]
+
+
+@pytest.mark.parametrize(
+    ("verify_ssl", "expected_ssl"),
+    [
+        (True, None),
+        (False, False),
+    ],
+)
+async def test_send_request_forwards_verify_ssl_to_session(
+    verify_ssl: bool, expected_ssl: bool | None
+) -> None:
+    session = FakeSession([{"jsonrpc": "2.0", "result": {"ok": True}, "id": 0}])
+    client = GLinetApiClient(
+        "http://router/rpc", session, verify_ssl=verify_ssl
+    )
+
+    assert await client.is_router_reachable() is True
+
+    assert len(session.requests) == 1
+    assert session.requests[0]["ssl"] is expected_ssl
+
+
+async def test_send_request_defaults_to_aiohttp_default_ssl_verification() -> None:
+    session = FakeSession([{"jsonrpc": "2.0", "result": {"ok": True}, "id": 0}])
+    client = GLinetApiClient("http://router/rpc", session)
+
+    assert await client.is_router_reachable() is True
+
+    assert session.requests[0]["ssl"] is None

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -54,7 +54,9 @@ class FakeSession:
         self.responses = list(responses)
         self.requests: list[dict[str, Any]] = []
 
-    def post(self, url: str, json: dict[str, Any], timeout: int, ssl: Any = None) -> FakePostContext:
+    def post(
+        self, url: str, json: dict[str, Any], timeout: int, ssl: Any = None
+    ) -> FakePostContext:
         self.requests.append({"url": url, "json": json, "timeout": timeout})
         payload = self.responses.pop(0)
         if isinstance(payload, FakeResponse):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -54,7 +54,7 @@ class FakeSession:
         self.responses = list(responses)
         self.requests: list[dict[str, Any]] = []
 
-    def post(self, url: str, json: dict[str, Any], timeout: int) -> FakePostContext:
+    def post(self, url: str, json: dict[str, Any], timeout: int, ssl: Any = None) -> FakePostContext:
         self.requests.append({"url": url, "json": json, "timeout": timeout})
         payload = self.responses.pop(0)
         if isinstance(payload, FakeResponse):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -660,10 +660,10 @@ async def test_send_request_forwards_verify_ssl_to_session(
     assert session.requests[0]["ssl"] is expected_ssl
 
 
-async def test_send_request_defaults_to_aiohttp_default_ssl_verification() -> None:
+async def test_send_request_defaults_to_disabled_ssl_verification() -> None:
     session = FakeSession([{"jsonrpc": "2.0", "result": {"ok": True}, "id": 0}])
     client = GLinetApiClient("http://router/rpc", session)
 
     assert await client.is_router_reachable() is True
 
-    assert session.requests[0]["ssl"] is None
+    assert session.requests[0]["ssl"] is False

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -109,6 +109,62 @@ def test_wan_monitor_options_use_friendly_known_interface_names() -> None:
     ]
 
 
+async def test_process_user_input_persists_verify_ssl_choice(monkeypatch) -> None:
+    def fake_init(self, host: str, hass: Any, verify_ssl: bool = True) -> None:
+        self.host = host
+        self.username = DEFAULT_USERNAME
+        self.router_mac = "00:00:00:00:00:00"
+        self.router_model = "mr200"
+        self.wan_interfaces = ["wan"]
+
+    async def fake_check_reachable(self) -> bool:
+        return True
+
+    async def fake_attempt_login(self, password: str) -> bool:
+        return True
+
+    monkeypatch.setattr(SetupHub, "__init__", fake_init)
+    monkeypatch.setattr(SetupHub, "check_reachable", fake_check_reachable)
+    monkeypatch.setattr(SetupHub, "attempt_login", fake_attempt_login)
+
+    result = await process_user_input(
+        {
+            "host": "http://router",
+            "password": "secret",
+            "verify_ssl": False,
+        },
+        types.SimpleNamespace(),
+    )
+
+    assert result["data"]["verify_ssl"] is False
+
+
+async def test_process_user_input_defaults_verify_ssl_to_true(monkeypatch) -> None:
+    def fake_init(self, host: str, hass: Any, verify_ssl: bool = True) -> None:
+        self.host = host
+        self.username = DEFAULT_USERNAME
+        self.router_mac = "00:00:00:00:00:00"
+        self.router_model = "mr200"
+        self.wan_interfaces = ["wan"]
+
+    async def fake_check_reachable(self) -> bool:
+        return True
+
+    async def fake_attempt_login(self, password: str) -> bool:
+        return True
+
+    monkeypatch.setattr(SetupHub, "__init__", fake_init)
+    monkeypatch.setattr(SetupHub, "check_reachable", fake_check_reachable)
+    monkeypatch.setattr(SetupHub, "attempt_login", fake_attempt_login)
+
+    result = await process_user_input(
+        {"host": "http://router", "password": "secret"},
+        types.SimpleNamespace(),
+    )
+
+    assert result["data"]["verify_ssl"] is True
+
+
 def test_parallel_requests_default_is_false() -> None:
     assert DEFAULT_PARALLEL_REQUESTS is False
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,7 +22,7 @@ from custom_components.glinet_router.const import (
 
 
 async def test_process_user_input_stores_enabled_features(monkeypatch) -> None:
-    def fake_init(self, host: str, hass: Any) -> None:
+    def fake_init(self, host: str, hass: Any, verify_ssl: bool = True) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
         self.router_mac = "00:00:00:00:00:00"
@@ -58,7 +58,7 @@ async def test_process_user_input_stores_enabled_features(monkeypatch) -> None:
 
 
 async def test_process_user_input_defaults_enabled_features_when_missing(monkeypatch) -> None:
-    def fake_init(self, host: str, hass: Any) -> None:
+    def fake_init(self, host: str, hass: Any, verify_ssl: bool = True) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
         self.router_mac = "00:00:00:00:00:00"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -139,7 +139,7 @@ async def test_process_user_input_persists_verify_ssl_choice(monkeypatch) -> Non
     assert result["data"]["verify_ssl"] is False
 
 
-async def test_process_user_input_defaults_verify_ssl_to_true(monkeypatch) -> None:
+async def test_process_user_input_defaults_verify_ssl_to_false(monkeypatch) -> None:
     def fake_init(self, host: str, hass: Any, verify_ssl: bool = True) -> None:
         self.host = host
         self.username = DEFAULT_USERNAME
@@ -162,7 +162,7 @@ async def test_process_user_input_defaults_verify_ssl_to_true(monkeypatch) -> No
         types.SimpleNamespace(),
     )
 
-    assert result["data"]["verify_ssl"] is True
+    assert result["data"]["verify_ssl"] is False
 
 
 def test_parallel_requests_default_is_false() -> None:

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -11,6 +11,7 @@ from custom_components.glinet_router.const import (
     CONF_CLEANUP_DEVICES,
     CONF_ENABLED_FEATURES,
     CONF_SCAN_INTERVAL,
+    CONF_VERIFY_SSL,
     CONF_WAN_STATUS_MONITORS,
     FEATURE_REPEATER,
     FEATURE_WG_CLIENT,
@@ -1705,3 +1706,48 @@ def test_apply_option_updates_without_scan_interval_keeps_default() -> None:
 
     hub.apply_option_updates({"some_other_option": "value"})
     assert hub.update_interval == timedelta(seconds=30)
+
+
+def test_create_api_client_passes_verify_ssl_from_settings(monkeypatch) -> None:
+    from custom_components.glinet_router.api.client import GLinetApiClient
+
+    captured: dict[str, Any] = {}
+
+    def fake_constructor(self, *args: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(GLinetApiClient, "__init__", fake_constructor)
+
+    entry = _make_entry(
+        data={
+            "host": "http://192.168.8.1",
+            "password": "pass",
+            CONF_VERIFY_SSL: False,
+        }
+    )
+    hub = GLinetHub(MagicMock(), entry)
+
+    hub._create_api_client()
+
+    assert captured["verify_ssl"] is False
+    assert captured["base_url"] == "http://192.168.8.1/rpc"
+
+
+def test_create_api_client_defaults_verify_ssl_to_true(monkeypatch) -> None:
+    from custom_components.glinet_router.api.client import GLinetApiClient
+
+    captured: dict[str, Any] = {}
+
+    def fake_constructor(self, *args: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(GLinetApiClient, "__init__", fake_constructor)
+
+    entry = _make_entry(
+        data={"host": "http://192.168.8.1", "password": "pass"}
+    )
+    hub = GLinetHub(MagicMock(), entry)
+
+    hub._create_api_client()
+
+    assert captured["verify_ssl"] is True

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1733,7 +1733,7 @@ def test_create_api_client_passes_verify_ssl_from_settings(monkeypatch) -> None:
     assert captured["base_url"] == "http://192.168.8.1/rpc"
 
 
-def test_create_api_client_defaults_verify_ssl_to_true(monkeypatch) -> None:
+def test_create_api_client_defaults_verify_ssl_to_false(monkeypatch) -> None:
     from custom_components.glinet_router.api.client import GLinetApiClient
 
     captured: dict[str, Any] = {}
@@ -1750,4 +1750,4 @@ def test_create_api_client_defaults_verify_ssl_to_true(monkeypatch) -> None:
 
     hub._create_api_client()
 
-    assert captured["verify_ssl"] is True
+    assert captured["verify_ssl"] is False


### PR DESCRIPTION
I wasn't able to get the integration to connect to my router (GL-MT6000) because it doesn't allow the rpc API access outside of HTTPS. The integration's use of the HTTP library requires a valid certificate for https URLs. I added an option to disable verification of SSL certificates, which is on by default but can be unchecked during the configuration sequence.